### PR TITLE
Feature/custom route names

### DIFF
--- a/login-workflow/README.md
+++ b/login-workflow/README.md
@@ -67,19 +67,24 @@ constructor(pxbAuthConfig: PxbAuthConfig) {
 -   **allowDebugMode** (optional): _`boolean`_
     -   When true, presents a debug button on the login screen to allow access to deep link-based screens/flows
     -   Default: false
+-   **backgroundImage** (optional): _`string`_
+    -   Background image to be used within the auth workflow
 -   **contactEmail** (optional): _`string`_
     -   Contact email address to be shown on the support screen
     -   Default: provides a fake email address
 -   **contactPhone** (optional): _`string`_
     -   Contact phone number to be shown on the support screen (human-readable for display only).
     -   Default: provides a fake phone number
+-   **eulaScrollLock** (optional): _`boolean`_
+    -   Requires the EULA to be completed scrolled through before a user can accept it.
+    -   Default: true
 -   **htmlEula** (optional): _`boolean`_
     -   Set to true if your EULA needs to be rendered as HTML
     -   Default: false
 -   **passwordRequirements** (optional): _`PasswordRequirement[]`_
     -   An array of `PasswordRequirement` that must be satisfied when creating or changing a password.
     -   Default: Passwords must contain a number, uppercase letter, lowercase letter, special character, and be between 8 and 16 characters in length
--   **projectImage** (optional): _`number | string`_
+-   **projectImage** (optional): _`string`_
     -   Project image shown on splash screen and login screen.
     -   Dimensions of the image should be 534w x 152h with a transparent background. Differently sized images may not render properly on all devices.
     -   Default: Provides an example project image.

--- a/login-workflow/docs/existing-project-integration.md
+++ b/login-workflow/docs/existing-project-integration.md
@@ -47,13 +47,14 @@ All routes that require authentication can be protected using the `PxbAuthGuard`
 In the example below, the `/home` route can only be accessed if a user is logged in.
 
 ```
-import { authSubRoutes, PxbAuthGuard, AUTH_ROUTE } from '@pxblue/angular-auth-workflow';
+import { getAuthSubRoutes, PxbAuthGuard, AUTH_ROUTES } from '@pxblue/angular-auth-workflow';
 import { HomeComponent } from './pages/home/home.component';
 import { AuthComponent } from './pages/auth/auth.component';
 
+const authWorkflowRoutes = getAuthSubRoutes();
 const routes: Routes = [
-    { path: '', redirectTo: AUTH_ROUTE, pathMatch: 'full' },
-    { path: AUTH_ROUTE, component: AuthComponent, children: authSubRoutes },
+    { path: '', redirectTo: AUTH_ROUTES.AUTH_WORKFLOW, pathMatch: 'full' },
+    { path: AUTH_ROUTES.AUTH_WORKFLOW, component: AuthComponent, children: authWorkflowRoutes },
     {
         path: '',
         canActivate: [PxbAuthGuard],
@@ -64,7 +65,9 @@ const routes: Routes = [
 ];
 ```
 
-The following is the list of default routes found in `authSubRoutes`: 
+
+
+The following is the list of default routes found in `getAuthSubRoutes()`.  
 
 | Screen              | Description                                            | Default URL                       | 
 | ------------------- | ------------------------------------------------------ | --------------------------------- | 
@@ -75,6 +78,7 @@ The following is the list of default routes found in `authSubRoutes`:
 | Self Registration   | the first screen of the self-registration flow         | `'/auth/register/create-account'` |
 | Support             | the contact/support screen                             | `'/auth/support'`                 |
 
+Any route url can be overwritten by altering the `AUTH_ROUTES` object. 
 
 #### Provide API Services
 

--- a/login-workflow/example/src/app/app.routing.ts
+++ b/login-workflow/example/src/app/app.routing.ts
@@ -6,9 +6,8 @@ import { AuthComponent } from './pages/auth/auth.component';
 import { DashboardComponent } from './pages/dashboard/dashboard.component';
 
 // The default workflow routes can be overwritten if needed.
-AUTH_ROUTES.AUTH_WORKFLOW = '';
-AUTH_ROUTES.CONTACT_SUPPORT = 'help/assistance';
-AUTH_ROUTES.CREATE_ACCOUNT = 'create-account';
+AUTH_ROUTES.AUTH_WORKFLOW = 'auth';
+AUTH_ROUTES.CONTACT_SUPPORT = 'assistance';
 
 const authWorkflowRoutes = getAuthSubRoutes();
 const routes: Routes = [

--- a/login-workflow/example/src/app/app.routing.ts
+++ b/login-workflow/example/src/app/app.routing.ts
@@ -1,13 +1,18 @@
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
-import { authSubRoutes, PxbAuthGuard, AUTH_ROUTE } from '@pxblue/angular-auth-workflow';
+import { getAuthSubRoutes, PxbAuthGuard, AUTH_ROUTES } from '@pxblue/angular-auth-workflow';
 import { HomeComponent } from './pages/home/home.component';
 import { AuthComponent } from './pages/auth/auth.component';
 import { DashboardComponent } from './pages/dashboard/dashboard.component';
 
+// The default workflow routes can be overwritten if needed.
+AUTH_ROUTES.AUTH_WORKFLOW = 'auth';
+AUTH_ROUTES.CONTACT_SUPPORT = 'assistance';
+
+const authWorkflowRoutes = getAuthSubRoutes();
 const routes: Routes = [
-    { path: '', redirectTo: AUTH_ROUTE, pathMatch: 'full' },
-    { path: AUTH_ROUTE, component: AuthComponent, children: authSubRoutes },
+    { path: '', redirectTo: AUTH_ROUTES.AUTH_WORKFLOW, pathMatch: 'full' },
+    { path: AUTH_ROUTES.AUTH_WORKFLOW, component: AuthComponent, children: authWorkflowRoutes },
     {
         path: '',
         canActivate: [PxbAuthGuard],

--- a/login-workflow/example/src/app/app.routing.ts
+++ b/login-workflow/example/src/app/app.routing.ts
@@ -6,8 +6,9 @@ import { AuthComponent } from './pages/auth/auth.component';
 import { DashboardComponent } from './pages/dashboard/dashboard.component';
 
 // The default workflow routes can be overwritten if needed.
-AUTH_ROUTES.AUTH_WORKFLOW = 'auth';
-AUTH_ROUTES.CONTACT_SUPPORT = 'assistance';
+AUTH_ROUTES.AUTH_WORKFLOW = '';
+AUTH_ROUTES.CONTACT_SUPPORT = 'help/assistance';
+AUTH_ROUTES.CREATE_ACCOUNT = 'create-account';
 
 const authWorkflowRoutes = getAuthSubRoutes();
 const routes: Routes = [

--- a/login-workflow/example/src/app/pages/auth/auth.component.ts
+++ b/login-workflow/example/src/app/pages/auth/auth.component.ts
@@ -1,6 +1,6 @@
 import { Component } from '@angular/core';
 import { AbstractControl, ValidatorFn } from '@angular/forms';
-import { PxbAuthConfig } from '@pxblue/angular-auth-workflow';
+import { PxbAuthConfig, AUTH_ROUTES } from '@pxblue/angular-auth-workflow';
 
 @Component({
     selector: 'app-auth',
@@ -28,9 +28,9 @@ export class AuthComponent {
         pxbAuthConfig.backgroundImage = 'assets/images/background.svg';
         pxbAuthConfig.allowDebugMode = true;
         pxbAuthConfig.showSelfRegistration = false;
-        // If the homeRoute is not pre-populated by default route inspection, provide it below.
-        if (!pxbAuthConfig.homeRoute || pxbAuthConfig.homeRoute === '/') {
-            pxbAuthConfig.homeRoute = 'home';
+        // If the ON_AUTHENTICATED route is not pre-populated by PXB auth workflow, provide it below.
+        if (!AUTH_ROUTES.ON_AUTHENTICATED || AUTH_ROUTES.ON_AUTHENTICATED === '/') {
+            AUTH_ROUTES.ON_AUTHENTICATED = 'home';
         }
     }
 

--- a/login-workflow/example/src/app/pages/home/home.component.ts
+++ b/login-workflow/example/src/app/pages/home/home.component.ts
@@ -1,6 +1,6 @@
 import { Component } from '@angular/core';
 import { Router } from '@angular/router';
-import { PxbChangePasswordDialogService, AUTH_ROUTE, PxbAuthSecurityService } from '@pxblue/angular-auth-workflow';
+import { PxbChangePasswordDialogService, AUTH_ROUTES, PxbAuthSecurityService } from '@pxblue/angular-auth-workflow';
 
 @Component({
     selector: 'app-home',
@@ -21,6 +21,6 @@ export class HomeComponent {
     logout(): void {
         console.log('Logging a user out of the app.');
         this._pxbSecurityService.updateSecurityState({ isAuthenticatedUser: false });
-        void this._router.navigate([AUTH_ROUTE]);
+        void this._router.navigate([AUTH_ROUTES.AUTH_WORKFLOW]);
     }
 }

--- a/login-workflow/example/src/app/services/register-ui.service.ts
+++ b/login-workflow/example/src/app/services/register-ui.service.ts
@@ -79,7 +79,7 @@ export class RegisterUIService implements IPxbRegisterUIService {
         const urlParams = new URLSearchParams(window.location.search);
         const urlCode = urlParams.get('code');
         if (!validationCode) {
-          validationCode = urlCode;
+            validationCode = urlCode;
         }
         console.log(
             `Performing a sample CompleteRegistration request with the following credentials:\n firstName: ${firstName}\n lastName: ${lastName}\n phoneNumber: ${phoneNumber}\n password: ${password}\n validationCode: ${validationCode}\n email: ${email}`

--- a/login-workflow/src/auth/auth.component.ts
+++ b/login-workflow/src/auth/auth.component.ts
@@ -2,7 +2,7 @@ import { ChangeDetectorRef, Component, ElementRef, Input, OnInit, TemplateRef } 
 import { NavigationEnd, Router } from '@angular/router';
 import { PxbAuthConfig } from '../services/config/auth-config';
 import { isEmptyView } from '../util/view-utils';
-import { AUTH_ROUTES } from './auth.routes';
+import { matchesRoute } from '../util/matcher';
 import { PxbAuthUIService } from '../services/api/auth-ui.service';
 import { PxbAuthSecurityService, SecurityContext } from '../services/state/auth-security.service';
 import { PxbCreateAccountInviteComponent } from '../pages/create-account-invite/create-account-invite.component';
@@ -72,12 +72,6 @@ export class PxbAuthComponent implements OnInit {
         });
     }
 
-    matches(route: NavigationEnd, targetRoute: string): boolean {
-        const potentialAuthRoute = `/${AUTH_ROUTES.AUTH_WORKFLOW}/${targetRoute}`.replace('//', '/');
-        const urlNoParams = route.urlAfterRedirects.split('?')[0];
-        return urlNoParams === potentialAuthRoute;
-    }
-
     // This will listen for auth state loading changes and toggles the shared overlay loading screen.
     private _listenForAuthLoadingStateChanges(): void {
         this._pxbSecurityService.securityStateChanges().subscribe((state: SecurityContext) => {
@@ -91,12 +85,13 @@ export class PxbAuthComponent implements OnInit {
         this._router.events.subscribe((route) => {
             if (route instanceof NavigationEnd) {
                 this._resetSelectedRoute();
-                this.showLogin = this.matches(route, AUTH_ROUTES.LOGIN);
-                this.showResetPassword = this.matches(route, AUTH_ROUTES.RESET_PASSWORD);
-                this.showCreateAccount = this.matches(route, AUTH_ROUTES.CREATE_ACCOUNT);
-                this.showForgotPassword = this.matches(route, AUTH_ROUTES.FORGOT_PASSWORD);
-                this.showContactSupport = this.matches(route, AUTH_ROUTES.CONTACT_SUPPORT);
-                this.showCreateAccountInvite = this.matches(route, AUTH_ROUTES.CREATE_ACCOUNT_INVITE);
+                const url = route.urlAfterRedirects;
+                this.showLogin = matchesRoute(url, 'LOGIN');
+                this.showResetPassword = matchesRoute(url, 'RESET_PASSWORD');
+                this.showCreateAccount = matchesRoute(url, 'CREATE_ACCOUNT');
+                this.showForgotPassword = matchesRoute(url, 'FORGOT_PASSWORD');
+                this.showContactSupport = matchesRoute(url, 'CONTACT_SUPPORT');
+                this.showCreateAccountInvite = matchesRoute(url, 'CREATE_ACCOUNT_INVITE');
                 this._changeDetectorRef.detectChanges();
             }
         });

--- a/login-workflow/src/auth/auth.component.ts
+++ b/login-workflow/src/auth/auth.component.ts
@@ -2,14 +2,7 @@ import { ChangeDetectorRef, Component, ElementRef, Input, OnInit, TemplateRef } 
 import { NavigationEnd, Router } from '@angular/router';
 import { PxbAuthConfig } from '../services/config/auth-config';
 import { isEmptyView } from '../util/view-utils';
-import {
-    CONTACT_SUPPORT_ROUTE,
-    CREATE_ACCOUNT_INVITE_ROUTE,
-    CREATE_ACCOUNT_ROUTE,
-    FORGOT_PASSWORD_ROUTE,
-    LOGIN_ROUTE,
-    RESET_PASSWORD_ROUTE,
-} from './auth.routes';
+import { AUTH_ROUTES } from './auth.routes';
 import { PxbAuthUIService } from '../services/api/auth-ui.service';
 import { PxbAuthSecurityService, SecurityContext } from '../services/state/auth-security.service';
 import { PxbCreateAccountInviteComponent } from '../pages/create-account-invite/create-account-invite.component';
@@ -80,7 +73,7 @@ export class PxbAuthComponent implements OnInit {
     }
 
     matches(route: NavigationEnd, targetRoute: string): boolean {
-        const potentialAuthRoute = `/${this._pxbAuthConfig.authRoute}/${targetRoute}`;
+        const potentialAuthRoute = `/${AUTH_ROUTES.AUTH_WORKFLOW}/${targetRoute}`;
         return route.urlAfterRedirects.split('?')[0] === potentialAuthRoute;
     }
 
@@ -97,12 +90,12 @@ export class PxbAuthComponent implements OnInit {
         this._router.events.subscribe((route) => {
             if (route instanceof NavigationEnd) {
                 this._resetSelectedRoute();
-                this.showLogin = this.matches(route, LOGIN_ROUTE);
-                this.showResetPassword = this.matches(route, RESET_PASSWORD_ROUTE);
-                this.showCreateAccount = this.matches(route, CREATE_ACCOUNT_ROUTE);
-                this.showForgotPassword = this.matches(route, FORGOT_PASSWORD_ROUTE);
-                this.showContactSupport = this.matches(route, CONTACT_SUPPORT_ROUTE);
-                this.showCreateAccountInvite = this.matches(route, CREATE_ACCOUNT_INVITE_ROUTE);
+                this.showLogin = this.matches(route, AUTH_ROUTES.LOGIN);
+                this.showResetPassword = this.matches(route, AUTH_ROUTES.RESET_PASSWORD);
+                this.showCreateAccount = this.matches(route, AUTH_ROUTES.CREATE_ACCOUNT);
+                this.showForgotPassword = this.matches(route, AUTH_ROUTES.FORGOT_PASSWORD);
+                this.showContactSupport = this.matches(route, AUTH_ROUTES.CONTACT_SUPPORT);
+                this.showCreateAccountInvite = this.matches(route, AUTH_ROUTES.CREATE_ACCOUNT_INVITE);
                 this._changeDetectorRef.detectChanges();
             }
         });

--- a/login-workflow/src/auth/auth.component.ts
+++ b/login-workflow/src/auth/auth.component.ts
@@ -73,8 +73,9 @@ export class PxbAuthComponent implements OnInit {
     }
 
     matches(route: NavigationEnd, targetRoute: string): boolean {
-        const potentialAuthRoute = `/${AUTH_ROUTES.AUTH_WORKFLOW}/${targetRoute}`;
-        return route.urlAfterRedirects.split('?')[0] === potentialAuthRoute;
+        const potentialAuthRoute = `/${AUTH_ROUTES.AUTH_WORKFLOW}/${targetRoute}`.replace('//', '/');
+        const urlNoParams = route.urlAfterRedirects.split('?')[0];
+        return urlNoParams === potentialAuthRoute;
     }
 
     // This will listen for auth state loading changes and toggles the shared overlay loading screen.

--- a/login-workflow/src/auth/auth.routes.ts
+++ b/login-workflow/src/auth/auth.routes.ts
@@ -1,7 +1,10 @@
-export const LOGIN_ROUTE = 'login';
-export const AUTH_ROUTE = 'auth';
-export const RESET_PASSWORD_ROUTE = 'reset-password';
-export const FORGOT_PASSWORD_ROUTE = 'forgot-password';
-export const CREATE_ACCOUNT_ROUTE = 'register/create-account';
-export const CREATE_ACCOUNT_INVITE_ROUTE = 'register/invite';
-export const CONTACT_SUPPORT_ROUTE = 'support';
+export const AUTH_ROUTES = {
+    AUTH_WORKFLOW: 'auth',
+    LOGIN: 'login',
+    RESET_PASSWORD: 'reset-password',
+    FORGOT_PASSWORD: 'forgot-password',
+    CREATE_ACCOUNT: 'register/create-account',
+    CREATE_ACCOUNT_INVITE: 'register/invite',
+    CONTACT_SUPPORT: 'support',
+    ON_AUTHENTICATED: '',
+};

--- a/login-workflow/src/auth/auth.routing.ts
+++ b/login-workflow/src/auth/auth.routing.ts
@@ -1,25 +1,20 @@
-import { Routes } from '@angular/router';
 import { PxbLoginComponent } from '../pages/login/login.component';
 import { PxbForgotPasswordComponent } from '../pages/forgot-password/forgot-password.component';
 import { PxbResetPasswordComponent } from '../pages/reset-password/reset-password.component';
 import { PxbCreateAccountComponent } from '../pages/create-account/create-account.component';
-import {
-    CONTACT_SUPPORT_ROUTE,
-    CREATE_ACCOUNT_INVITE_ROUTE,
-    CREATE_ACCOUNT_ROUTE,
-    FORGOT_PASSWORD_ROUTE,
-    LOGIN_ROUTE,
-    RESET_PASSWORD_ROUTE,
-} from './auth.routes';
 import { PxbContactSupportComponent } from '../pages/contact-support/contact-support.component';
 import { PxbCreateAccountInviteComponent } from '../pages/create-account-invite/create-account-invite.component';
+import { AUTH_ROUTES } from './auth.routes';
+import { Routes } from '@angular/router';
 
-export const authSubRoutes: Routes = [
-    { path: '', redirectTo: LOGIN_ROUTE, pathMatch: 'full' },
-    { path: LOGIN_ROUTE, component: PxbLoginComponent },
-    { path: RESET_PASSWORD_ROUTE, component: PxbResetPasswordComponent },
-    { path: FORGOT_PASSWORD_ROUTE, component: PxbForgotPasswordComponent },
-    { path: CREATE_ACCOUNT_ROUTE, component: PxbCreateAccountComponent },
-    { path: CONTACT_SUPPORT_ROUTE, component: PxbContactSupportComponent },
-    { path: CREATE_ACCOUNT_INVITE_ROUTE, component: PxbCreateAccountInviteComponent },
-];
+export function getAuthSubRoutes(): Routes {
+    return [
+        { path: '', redirectTo: AUTH_ROUTES.LOGIN, pathMatch: 'full' },
+        { path: AUTH_ROUTES.LOGIN, component: PxbLoginComponent },
+        { path: AUTH_ROUTES.RESET_PASSWORD, component: PxbResetPasswordComponent },
+        { path: AUTH_ROUTES.FORGOT_PASSWORD, component: PxbForgotPasswordComponent },
+        { path: AUTH_ROUTES.CREATE_ACCOUNT, component: PxbCreateAccountComponent },
+        { path: AUTH_ROUTES.CONTACT_SUPPORT, component: PxbContactSupportComponent },
+        { path: AUTH_ROUTES.CREATE_ACCOUNT_INVITE, component: PxbCreateAccountInviteComponent },
+    ];
+};

--- a/login-workflow/src/auth/auth.routing.ts
+++ b/login-workflow/src/auth/auth.routing.ts
@@ -17,4 +17,4 @@ export function getAuthSubRoutes(): Routes {
         { path: AUTH_ROUTES.CONTACT_SUPPORT, component: PxbContactSupportComponent },
         { path: AUTH_ROUTES.CREATE_ACCOUNT_INVITE, component: PxbCreateAccountInviteComponent },
     ];
-};
+}

--- a/login-workflow/src/pages/change-password/change-password.component.ts
+++ b/login-workflow/src/pages/change-password/change-password.component.ts
@@ -4,7 +4,7 @@ import { Router } from '@angular/router';
 
 import { PxbAuthUIService } from '../../services/api/auth-ui.service';
 import { PxbAuthSecurityService } from '../../services/state/auth-security.service';
-import { LOGIN_ROUTE } from '../../auth/auth.routes';
+import { AUTH_ROUTES } from '../../auth/auth.routes';
 import { PxbAuthConfig } from '../../services/config/auth-config';
 import { PasswordRequirement } from '../../components/password-strength-checker/pxb-password-strength-checker.component';
 import { PxbChangePasswordDialogService } from './dialog/change-password-dialog.service';
@@ -84,7 +84,7 @@ export class PxbChangePasswordComponent {
 
     done(): void {
         this.closeDialog();
-        void this._router.navigate([`${this._pxbAuthConfig.authRoute}/${LOGIN_ROUTE}`]);
+        void this._router.navigate([`${AUTH_ROUTES.AUTH_WORKFLOW}/${AUTH_ROUTES.LOGIN}`]);
     }
 
     changePassword(): void {

--- a/login-workflow/src/pages/contact-support/contact-support.component.ts
+++ b/login-workflow/src/pages/contact-support/contact-support.component.ts
@@ -1,6 +1,6 @@
 import { Component } from '@angular/core';
 import { Router } from '@angular/router';
-import { LOGIN_ROUTE } from '../../auth/auth.routes';
+import { AUTH_ROUTES } from '../../auth/auth.routes';
 import { PxbAuthConfig } from '../../services/config/auth-config';
 
 @Component({
@@ -15,6 +15,6 @@ export class PxbContactSupportComponent {
     constructor(private readonly _router: Router, public authConfig: PxbAuthConfig) {}
 
     navigateToLogin(): void {
-        void this._router.navigate([`${this.authConfig.authRoute}/${LOGIN_ROUTE}`]);
+        void this._router.navigate([`${AUTH_ROUTES.AUTH_WORKFLOW}/${AUTH_ROUTES.LOGIN}`]);
     }
 }

--- a/login-workflow/src/pages/create-account-invite/create-account-invite.component.ts
+++ b/login-workflow/src/pages/create-account-invite/create-account-invite.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
 
-import { LOGIN_ROUTE } from '../../auth/auth.routes';
+import { AUTH_ROUTES } from '../../auth/auth.routes';
 import { PxbAuthConfig } from '../../services/config/auth-config';
 import { PxbRegisterUIService } from '../../services/api/register-ui.service';
 import { PxbAuthSecurityService, SecurityContext } from '../../services/state/auth-security.service';
@@ -103,6 +103,6 @@ export class PxbCreateAccountInviteComponent implements OnInit {
     }
 
     navigateToLogin(): void {
-        void this._router.navigate([`${this._pxbAuthConfig.authRoute}/${LOGIN_ROUTE}`]);
+        void this._router.navigate([`${AUTH_ROUTES.AUTH_WORKFLOW}/${AUTH_ROUTES.LOGIN}`]);
     }
 }

--- a/login-workflow/src/pages/create-account/create-account.component.html
+++ b/login-workflow/src/pages/create-account/create-account.component.html
@@ -40,7 +40,7 @@
 <mat-divider class="pxb-auth-divider" style="margin-bottom: 16px;"></mat-divider>
 <div class="pxb-auth-action-button-container">
     <ng-container *ngIf="currentPageId <= 4">
-        <pxb-mobile-stepper [steps]="4" [activeStep]="currentPageId">
+        <pxb-mobile-stepper [steps]="6" [activeStep]="currentPageId">
             <button pxb-back-button mat-stroked-button color="primary" style="width: 100px;" (click)="goBack()">
                 Back
             </button>

--- a/login-workflow/src/pages/create-account/create-account.component.ts
+++ b/login-workflow/src/pages/create-account/create-account.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 import { Router } from '@angular/router';
 
-import { LOGIN_ROUTE } from '../../auth/auth.routes';
+import { AUTH_ROUTES } from '../../auth/auth.routes';
 import { PxbAuthConfig } from '../../services/config/auth-config';
 import { PxbRegisterUIService } from '../../services/api/register-ui.service';
 import { PxbAuthSecurityService, SecurityContext } from '../../services/state/auth-security.service';
@@ -119,6 +119,6 @@ export class PxbCreateAccountComponent {
     }
 
     navigateToLogin(): void {
-        void this._router.navigate([`${this._pxbAuthConfig.authRoute}/${LOGIN_ROUTE}`]);
+        void this._router.navigate([`${AUTH_ROUTES.AUTH_WORKFLOW}/${AUTH_ROUTES.LOGIN}`]);
     }
 }

--- a/login-workflow/src/pages/forgot-password/forgot-password.component.ts
+++ b/login-workflow/src/pages/forgot-password/forgot-password.component.ts
@@ -4,7 +4,7 @@ import { Router } from '@angular/router';
 import { AuthErrorStateMatcher } from '../../util/matcher';
 import { PXB_LOGIN_VALIDATOR_ERROR_NAME } from '../login/login.component';
 import { PxbAuthUIService } from '../../services/api/auth-ui.service';
-import { FORGOT_PASSWORD_ROUTE, LOGIN_ROUTE } from '../../auth/auth.routes';
+import { AUTH_ROUTES } from '../../auth/auth.routes';
 import { PxbAuthConfig } from '../../services/config/auth-config';
 import { PxbAuthSecurityService } from '../../services/state/auth-security.service';
 import { PxbForgotPasswordErrorDialogService } from '../../services/dialog/forgot-password-error-dialog.service';
@@ -48,7 +48,7 @@ export class PxbForgotPasswordComponent implements OnInit {
     }
 
     navigateToLogin(): void {
-        void this._router.navigate([`${this.pxbAuthConfig.authRoute}/${LOGIN_ROUTE}`]);
+        void this._router.navigate([`${AUTH_ROUTES.AUTH_WORKFLOW}/${AUTH_ROUTES.LOGIN}`]);
     }
 
     resetPassword(): void {
@@ -65,7 +65,7 @@ export class PxbForgotPasswordComponent implements OnInit {
             .forgotPassword(email)
             .then(() => {
                 this.passwordResetSuccess = true;
-                void this._router.navigate([`${this.pxbAuthConfig.authRoute}/${FORGOT_PASSWORD_ROUTE}`]);
+                void this._router.navigate([`${AUTH_ROUTES.AUTH_WORKFLOW}/${AUTH_ROUTES.FORGOT_PASSWORD}`]);
                 this._pxbSecurityService.setLoading(false);
             })
             .catch((data: ErrorDialogData) => {

--- a/login-workflow/src/pages/login/login.component.ts
+++ b/login-workflow/src/pages/login/login.component.ts
@@ -4,14 +4,7 @@ import { FormControl, ValidatorFn, Validators } from '@angular/forms';
 import { isEmptyView } from '../../util/view-utils';
 import { PxbAuthSecurityService } from '../../services/state/auth-security.service';
 import { PxbAuthUIService } from '../../services/api/auth-ui.service';
-import {
-    CONTACT_SUPPORT_ROUTE,
-    CREATE_ACCOUNT_INVITE_ROUTE,
-    CREATE_ACCOUNT_ROUTE,
-    FORGOT_PASSWORD_ROUTE,
-    RESET_PASSWORD_ROUTE,
-} from '../../auth/auth.routes';
-
+import { AUTH_ROUTES } from '../../auth/auth.routes';
 import { PxbAuthConfig } from '../../services/config/auth-config';
 import { PxbLoginErrorDialogService } from '../../services/dialog/login-error-dialog.service';
 import { ErrorDialogData } from '../../services/dialog/error-dialog.service';
@@ -106,7 +99,7 @@ export class PxbLoginComponent implements OnInit, AfterViewInit {
             .login(email, password, rememberMe)
             .then(() => {
                 this._pxbSecurityService.onUserAuthenticated(email, password, rememberMe);
-                this.navigateToDefaultRoute(); // TODO: User needs to provide this route somehow.
+                this.navigateToDefaultRoute();
                 this._pxbSecurityService.setLoading(false);
             })
             .catch((data: ErrorDialogData) => {
@@ -122,31 +115,31 @@ export class PxbLoginComponent implements OnInit, AfterViewInit {
     }
 
     navigateToDefaultRoute(): void {
-        void this._router.navigate([this._pxbAuthConfig.homeRoute]);
+        void this._router.navigate([AUTH_ROUTES.ON_AUTHENTICATED]);
     }
 
     forgotPassword(): void {
-        void this._router.navigate([`${this._pxbAuthConfig.authRoute}/${FORGOT_PASSWORD_ROUTE}`]);
+        void this._router.navigate([`${AUTH_ROUTES.AUTH_WORKFLOW}/${AUTH_ROUTES.FORGOT_PASSWORD}`]);
     }
 
     testForgotPasswordEmail(): void {
-        void this._router.navigate([`${this._pxbAuthConfig.authRoute}/${RESET_PASSWORD_ROUTE}`], {
+        void this._router.navigate([`${AUTH_ROUTES.AUTH_WORKFLOW}/${AUTH_ROUTES.RESET_PASSWORD}`], {
             queryParams: { code: 'DEADBEEF', email: 'resetPassword@email.com' },
         });
     }
 
     testInviteRegister(): void {
-        void this._router.navigate([`${this._pxbAuthConfig.authRoute}/${CREATE_ACCOUNT_INVITE_ROUTE}`], {
+        void this._router.navigate([`${AUTH_ROUTES.AUTH_WORKFLOW}/${AUTH_ROUTES.CREATE_ACCOUNT_INVITE}`], {
             queryParams: { code: 'DEADBEEF' },
         });
     }
 
     createAccount(): void {
-        void this._router.navigate([`${this._pxbAuthConfig.authRoute}/${CREATE_ACCOUNT_ROUTE}`]);
+        void this._router.navigate([`${AUTH_ROUTES.AUTH_WORKFLOW}/${AUTH_ROUTES.CREATE_ACCOUNT}`]);
     }
 
     contactSupport(): void {
-        void this._router.navigate([`${this._pxbAuthConfig.authRoute}/${CONTACT_SUPPORT_ROUTE}`]);
+        void this._router.navigate([`${AUTH_ROUTES.AUTH_WORKFLOW}/${AUTH_ROUTES.CONTACT_SUPPORT}`]);
     }
 
     isValidFormEntries(): boolean {

--- a/login-workflow/src/pages/reset-password/reset-password.component.ts
+++ b/login-workflow/src/pages/reset-password/reset-password.component.ts
@@ -3,7 +3,7 @@ import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { Router } from '@angular/router';
 import { PxbAuthSecurityService, SecurityContext } from '../../services/state/auth-security.service';
 import { PxbAuthUIService } from '../../services/api/auth-ui.service';
-import { LOGIN_ROUTE } from '../../auth/auth.routes';
+import { AUTH_ROUTES } from '../../auth/auth.routes';
 import { PxbAuthConfig } from '../../services/config/auth-config';
 import { PxbResetPasswordErrorDialogService } from '../../services/dialog/reset-password-error-dialog.service';
 import { PasswordRequirement } from '../../components/password-strength-checker/pxb-password-strength-checker.component';
@@ -104,7 +104,7 @@ export class PxbResetPasswordComponent implements OnInit {
     }
 
     navigateToLogin(): void {
-        void this._router.navigate([`${this._pxbAuthConfig.authRoute}/${LOGIN_ROUTE}`]);
+        void this._router.navigate([`${AUTH_ROUTES.AUTH_WORKFLOW}/${AUTH_ROUTES.LOGIN}`]);
     }
 
     resetPassword(): void {

--- a/login-workflow/src/services/config/auth-config.ts
+++ b/login-workflow/src/services/config/auth-config.ts
@@ -8,8 +8,6 @@ export type PasswordRequirement = {
     providedIn: 'root',
 })
 export class PxbAuthConfig implements PxbAuthConfig {
-    homeRoute = 'home'; // TODO: Rename this to 'onAuthenticatedRoute'
-    authRoute = 'auth';
     contactEmail = 'something@email.com';
     contactPhone = '1-800-123-4567';
     // @TODO: using this for splash screen... should we use this in place of ng-content for header in the login component? Should we have an additional prop for footerImage
@@ -39,7 +37,6 @@ export class PxbAuthConfig implements PxbAuthConfig {
             regex: /[!"#$%&'()*+,-./:;<=>?@[\]^`{|}~]+/,
         },
     ];
-
     eula: string;
     htmlEula = false;
     allowDebugMode = false;

--- a/login-workflow/src/services/state/auth-security.service.ts
+++ b/login-workflow/src/services/state/auth-security.service.ts
@@ -3,6 +3,7 @@ import { Observable, Subject } from 'rxjs';
 import { NavigationStart, Router } from '@angular/router';
 import { PxbAuthConfig } from '../../services/config/auth-config';
 import { AUTH_ROUTES } from '../../auth/auth.routes';
+import { matchesRoute } from '../../util/matcher';
 
 export type SecurityContext = {
     /**
@@ -70,10 +71,18 @@ export class PxbAuthSecurityService {
         _router.events.subscribe((event) => {
             if (event instanceof NavigationStart && !this.isFirstRouteCaptured) {
                 this.isFirstRouteCaptured = true;
-                if (!event.url.includes(AUTH_ROUTES.AUTH_WORKFLOW) || event.url === '/') {
-                    if (!AUTH_ROUTES.ON_AUTHENTICATED) {
-                        AUTH_ROUTES.ON_AUTHENTICATED = event.url;
-                    }
+                const url = event.url;
+                // If the initial route loaded is not part of the auth workflow, make it so authenticated users will redirect to it post-login.
+                if (
+                    !matchesRoute(url, 'LOGIN') &&
+                    !matchesRoute(url, 'CONTACT_SUPPORT') &&
+                    !matchesRoute(url, 'CREATE_ACCOUNT') &&
+                    !matchesRoute(url, 'CREATE_ACCOUNT_INVITE') &&
+                    !matchesRoute(url, 'FORGOT_PASSWORD') &&
+                    !matchesRoute(url, 'RESET_PASSWORD') &&
+                    !matchesRoute(url, 'AUTH_WORKFLOW')
+                ) {
+                    AUTH_ROUTES.ON_AUTHENTICATED = event.url;
                 }
             }
         });

--- a/login-workflow/src/services/state/auth-security.service.ts
+++ b/login-workflow/src/services/state/auth-security.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@angular/core';
 import { Observable, Subject } from 'rxjs';
 import { NavigationStart, Router } from '@angular/router';
 import { PxbAuthConfig } from '../../services/config/auth-config';
-import { AUTH_ROUTE } from '../../auth/auth.routes';
+import { AUTH_ROUTES } from '../../auth/auth.routes';
 
 export type SecurityContext = {
     /**
@@ -70,8 +70,10 @@ export class PxbAuthSecurityService {
         _router.events.subscribe((event) => {
             if (event instanceof NavigationStart && !this.isFirstRouteCaptured) {
                 this.isFirstRouteCaptured = true;
-                if (!event.url.includes(AUTH_ROUTE) || event.url === '/') {
-                    this._pxbAuthConfig.homeRoute = event.url;
+                if (!event.url.includes(AUTH_ROUTES.AUTH_WORKFLOW) || event.url === '/') {
+                    if (!AUTH_ROUTES.ON_AUTHENTICATED) {
+                        AUTH_ROUTES.ON_AUTHENTICATED = event.url;
+                    }
                 }
             }
         });

--- a/login-workflow/src/util/matcher.ts
+++ b/login-workflow/src/util/matcher.ts
@@ -1,5 +1,6 @@
 import { ErrorStateMatcher } from '@angular/material/core';
 import { FormControl, FormGroupDirective, NgForm } from '@angular/forms';
+import { AUTH_ROUTES } from '..';
 
 /** Error when invalid control is touched, or submitted. */
 export class AuthErrorStateMatcher implements ErrorStateMatcher {
@@ -14,3 +15,10 @@ export class CrossFieldErrorMatcher implements ErrorStateMatcher {
         return control.touched && form.invalid;
     }
 }
+
+// Returns true if a route (minus params) equals a target route
+export const matchesRoute = (route: string, authRouteKey: keyof typeof AUTH_ROUTES): boolean => {
+    const authRoute = `/${AUTH_ROUTES.AUTH_WORKFLOW}/${AUTH_ROUTES[authRouteKey]}`.replace('//', '/');
+    const urlNoParams = route.split('?')[0];
+    return urlNoParams === authRoute;
+};


### PR DESCRIPTION
<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Add 6 steps to `create-account` mobile stepper
- Make routes urls customizable.

```
// The default workflow routes can be overwritten if needed.
AUTH_ROUTES.AUTH_WORKFLOW = 'auth';
AUTH_ROUTES.CONTACT_SUPPORT = 'assistance';
```
