### PR TITLE
Feature/custom account details

### DIFF
--- a/login-workflow/README.md
+++ b/login-workflow/README.md
@@ -401,7 +401,7 @@ See the example project (`./src/app/dialog/login-error-dialog.component.ts`) for
 ```
 
 
-# Custom Registration Requirements
+# Custom Account Details
 To add custom form fields to the self registration pages, follow the steps below:
 
 ### Create a custom `<pxb-create-account>` component.

--- a/login-workflow/README.md
+++ b/login-workflow/README.md
@@ -402,8 +402,70 @@ See the example project (`./src/app/dialog/login-error-dialog.component.ts`) for
 
 
 # Custom Registration Requirements
+To add custom form fields to the self registration pages, follow the steps below:
 
-TODO: Custom account registration docs go here. 
+### Create a custom `<pxb-create-account>` component.
+```angular2
+<ng-template #createAccountPage>
+    <pxb-create-account [accountDetails]="accountDetails"></pxb-create-account>
+</ng-template>
+
+<pxb-auth [createAccountRef]="createAccountPage"></pxb-auth>
+``` 
+
+### Add your custom form content as a `<ng-template>`
+```angular2
+<ng-template #customFormRef>
+  <form>
+      <mat-form-field appearance="fill">
+          <mat-label>Custom Field</mat-label>
+          <input matInput [formControl]="customFormControl" required />
+          <mat-error *ngIf="customFormControl.hasError('required')">
+              Emergency Contact is <strong>required</strong>
+          </mat-error>
+      </mat-form-field>
+  </form>
+</ng-template>
+```
+
+### Populate the `accountDetails` @Input
+Each `accountDetails` object has 3 properties:
+
+`form`: what to render
+
+`formControls`: access what the user entered
+
+`isValid()`: function we run to determine if user-input is valid.
+
+
+Each `accountDetails` represents a new page in the self-registration process.  
+```
+import { AccountDetails } from '@pxblue/angular-auth-workflow';
+
+
+// What to Render
+@ViewChild('customFormRef') customFormRef: TemplateRef<MatFormField>;
+
+// To capture user inputs
+customFormControl: FormControl;
+
+// An array of accountDetails where each object represents a new page. 
+accountDetails: AccountDetails[]; 
+
+ngAfterViewInit(): void {
+  this.customFormControl= new FormControl('', Validators.required);
+  this.accountDetails = [
+      {   /* Page 1 */
+          form: this.customFormRef,
+          formControls: new Map([['custom', this.customFormControl]]),
+          isValid: () => this.customFormControl.value,
+      }
+  ];
+}
+
+```
+
+This solution scales so that a user can have as many pages as they want.  Adding `undefined` as the first entry of the `accountDetails[]` will shift all custom forms onto their own page. 
 
 
 ## Auth Component

--- a/login-workflow/README.md
+++ b/login-workflow/README.md
@@ -465,7 +465,9 @@ ngAfterViewInit(): void {
 
 ```
 
-This solution scales so that a user can have as many pages as they want.  Adding `undefined` as the first entry of the `accountDetails[]` will shift all custom forms onto their own page. 
+This solution scales so that a user can have as many pages as they want.  Adding `undefined` as the first entry of the `accountDetails[]` will shift all custom forms onto their own page.  
+
+Check out the Example project to see an example of custom registration forms.
 
 
 ## Auth Component

--- a/login-workflow/README.md
+++ b/login-workflow/README.md
@@ -400,6 +400,12 @@ See the example project (`./src/app/dialog/login-error-dialog.component.ts`) for
 </pxb-auth>
 ```
 
+
+# Custom Registration Requirements
+
+TODO: Custom account registration docs go here. 
+
+
 ## Auth Component
 The Auth Component is the top level `<pxb-auth>` component that houses all pages with the auth workflow.
 This component accepts @Inputs for individual page customizations.

--- a/login-workflow/example/src/app/pages/auth/auth.component.ts
+++ b/login-workflow/example/src/app/pages/auth/auth.component.ts
@@ -20,7 +20,7 @@ import { MatFormField } from '@angular/material/form-field';
 
         <!-- Custom Create Account page -->
         <ng-template #createAccountPage>
-            <pxb-create-account #createAccount [accountDetails]="accountDetails"></pxb-create-account>
+            <pxb-create-account #createAccountVC [accountDetails]="accountDetails"></pxb-create-account>
         </ng-template>
 
         <!-- Custom Create Account page -->
@@ -42,7 +42,7 @@ import { MatFormField } from '@angular/material/form-field';
                         Country is <strong>required</strong>
                     </mat-error>
                 </mat-form-field>
-                <mat-form-field appearance="fill" [style.width.%]="100" [style.marginBottom.px]="8">
+                <mat-form-field appearance="fill">
                     <mat-label>Phone Number (optional)</mat-label>
                     <input matInput [formControl]="phoneNumberFormControl"
                            (keyup.enter)="createAccount.canContinue() ? createAccount.goNext() : ''"/>
@@ -52,7 +52,7 @@ import { MatFormField } from '@angular/material/form-field';
 
         <ng-template #accountDetailsPage2>
             <form>
-                <mat-form-field appearance="fill" [style.width.%]="100" [style.marginBottom.px]="8">
+                <mat-form-field appearance="fill">
                     <mat-label>Emergency Contact Number</mat-label>
                     <input matInput [formControl]="emergencyFormControl" required />
                     <mat-error *ngIf="emergencyFormControl.hasError('required')">
@@ -78,7 +78,7 @@ export class AuthComponent {
 
     @ViewChild('accountDetailsPage1') accountDetailsPage1: TemplateRef<MatFormField>;
     @ViewChild('accountDetailsPage2') accountDetailsPage2: TemplateRef<MatFormField>;
-    @ViewChild('createAccount') createAccount: PxbCreateAccountComponent;
+    @ViewChild('createAccountVC') createAccountVC: PxbCreateAccountComponent;
 
     countries: any[] = [
         { value: 'US', viewValue: 'US' },

--- a/login-workflow/example/src/app/pages/auth/auth.component.ts
+++ b/login-workflow/example/src/app/pages/auth/auth.component.ts
@@ -1,6 +1,7 @@
-import { Component } from '@angular/core';
-import { AbstractControl, FormControl, ValidatorFn, Validators } from '@angular/forms';
+import {Component, Input, TemplateRef, ViewChild} from '@angular/core';
+import {AbstractControl, Form, FormControl, ValidatorFn, Validators} from '@angular/forms';
 import { PxbAuthConfig, AUTH_ROUTES, AccountDetails } from '@pxblue/angular-auth-workflow';
+import {MatFormField} from "@angular/material/form-field";
 
 @Component({
     selector: 'app-auth',
@@ -19,22 +20,16 @@ import { PxbAuthConfig, AUTH_ROUTES, AccountDetails } from '@pxblue/angular-auth
 
         <!-- Custom Create Account page -->
         <ng-template #createAccountPage>
-            <pxb-create-account [accountDetails]="accountDetails">
-                <template pxb-account-details-page-0 [ngTemplateOutlet]="accountDetailsFirstPage"></template>
-                <template pxb-account-details-page-1 [ngTemplateOutlet]="accountDetailsSecondPage"></template>
-            </pxb-create-account>
+            <pxb-create-account [accountDetails]="accountDetails"></pxb-create-account>
         </ng-template>
 
         <!-- Custom Create Account page -->
         <ng-template #createAccountViaInvitePage>
-            <pxb-create-account-invite [accountDetails]="accountDetails">
-                <template pxb-account-details-page-0 [ngTemplateOutlet]="accountDetailsFirstPage"></template>
-                <template pxb-account-details-page-1 [ngTemplateOutlet]="accountDetailsSecondPage"></template>
-            </pxb-create-account-invite>
+            <pxb-create-account-invite [accountDetails]="accountDetails"></pxb-create-account-invite>
         </ng-template>
 
         <!-- This is an example of a custom account details form.  To enable the defaults, remove this template and the accountDetails[]. -->
-        <ng-template #accountDetailsFirstPage>
+        <ng-template #accountDetailsPage1>
             <form>
                 <mat-form-field appearance="fill" [style.width.%]="100" [style.marginBottom.px]="8">
                     <mat-label>Country</mat-label>
@@ -54,7 +49,7 @@ import { PxbAuthConfig, AUTH_ROUTES, AccountDetails } from '@pxblue/angular-auth
             </form>
         </ng-template>
 
-        <ng-template #accountDetailsSecondPage>
+        <ng-template #accountDetailsPage2>
             <form>
                 <mat-form-field appearance="fill" [style.width.%]="100" [style.marginBottom.px]="8">
                     <mat-label>Emergency Contact Number</mat-label>
@@ -80,6 +75,9 @@ export class AuthComponent {
     emergencyFormControl: FormControl;
     accountDetails: AccountDetails[];
 
+    @ViewChild('accountDetailsPage1') accountDetailsPage1: TemplateRef<MatFormField>;
+    @ViewChild('accountDetailsPage2') accountDetailsPage2: TemplateRef<MatFormField>;
+
     countries: any[] = [
         { value: 'US', viewValue: 'US' },
         { value: 'UK', viewValue: 'UK' },
@@ -100,7 +98,7 @@ export class AuthComponent {
         }
     }
 
-    ngOnInit(): void {
+    ngAfterViewInit(): void {
         this.initCreateAccountFormControls();
     }
 
@@ -109,11 +107,16 @@ export class AuthComponent {
         this.phoneNumberFormControl = new FormControl('');
         this.emergencyFormControl = new FormControl('', Validators.required);
         this.accountDetails = [
+          {
+            form: undefined, formControls: undefined, isValid: () => true,
+          },
             {
+              form: this.accountDetailsPage1,
                 formControls: [this.countryFormControl, this.phoneNumberFormControl],
                 isValid: () => this.countryFormControl.value,
             },
             {
+              form: this.accountDetailsPage2,
                 formControls: [this.emergencyFormControl],
                 isValid: () => this.emergencyFormControl.value,
             },

--- a/login-workflow/example/src/app/pages/auth/auth.component.ts
+++ b/login-workflow/example/src/app/pages/auth/auth.component.ts
@@ -31,40 +31,47 @@ import { AccountDetails, AUTH_ROUTES, PxbAuthConfig, PxbCreateAccountComponent, 
         <!-- This is an example of a custom account details form.  To enable the defaults, remove this template and the accountDetails[]. -->
         <ng-template #accountDetailsPage1>
             <form>
-                <mat-form-field appearance="fill" [style.width.%]="100" [style.marginBottom.px]="8">
-                    <mat-label>Country</mat-label>
-                    <mat-select [formControl]="countryFormControl" required>
-                        <mat-option *ngFor="let country of countries" [value]="country.value">
-                            {{ country.viewValue }}
-                        </mat-option>
-                    </mat-select>
-                    <mat-error *ngIf="countryFormControl.hasError('required')">
-                        Country is <strong>required</strong>
+              <div style="display: flex;">
+                <mat-form-field appearance="fill"  [style.maxWidth.px]="170">
+                  <mat-label>Country Code</mat-label>
+                  <mat-select [formControl]="countryFormControl" required>
+                    <mat-option *ngFor="let country of countries" [value]="country.value">
+                      {{ country.viewValue }}
+                    </mat-option>
+                  </mat-select>
+                  <mat-error *ngIf="countryFormControl.hasError('required')">
+                    Code is <strong>required</strong>
+                  </mat-error>
+                </mat-form-field >
+                  <mat-form-field appearance="fill" [style.marginLeft.px]="16">
+                      <mat-label>Phone Number</mat-label>
+                      <input
+                          matInput
+                          required
+                          [formControl]="phoneNumberFormControl"
+                          (keyup.enter)="attemptGoNext()"
+                      />
+
+                    <mat-error *ngIf="phoneNumberFormControl.hasError('required')">
+                      Code is <strong>required</strong>
                     </mat-error>
-                </mat-form-field>
-                <mat-form-field appearance="fill">
-                    <mat-label>Phone Number (optional)</mat-label>
-                    <input
-                        matInput
-                        [formControl]="phoneNumberFormControl"
-                        (keyup.enter)="attemptGoNext()"
-                    />
-                </mat-form-field>
+                  </mat-form-field>
+                </div>
             </form>
         </ng-template>
 
         <ng-template #accountDetailsPage2>
             <form>
                 <mat-form-field appearance="fill">
-                    <mat-label>Emergency Contact Number</mat-label>
+                    <mat-label>Job Title</mat-label>
                     <input
                         matInput
-                        [formControl]="emergencyFormControl"
+                        [formControl]="jobTitleFromControl"
                         required
                         (keyup.enter)="attemptGoNext()"
                     />
-                    <mat-error *ngIf="emergencyFormControl.hasError('required')">
-                        Emergency Contact is <strong>required</strong>
+                    <mat-error *ngIf="jobTitleFromControl.hasError('required')">
+                        Job Title is <strong>required</strong>
                     </mat-error>
                 </mat-form-field>
             </form>
@@ -81,7 +88,7 @@ import { AccountDetails, AUTH_ROUTES, PxbAuthConfig, PxbCreateAccountComponent, 
 export class AuthComponent {
     countryFormControl: FormControl;
     phoneNumberFormControl: FormControl;
-    emergencyFormControl: FormControl;
+    jobTitleFromControl: FormControl;
     accountDetails: AccountDetails[];
 
   @ViewChild('createAccountVC') createAccountVC: PxbCreateAccountComponent;
@@ -91,8 +98,10 @@ export class AuthComponent {
     @ViewChild('accountDetailsPage2') accountDetailsPage2: TemplateRef<MatFormField>;
 
     countries: any[] = [
-        { value: 'US', viewValue: 'US' },
-        { value: 'UK', viewValue: 'UK' },
+        { value: 'US', viewValue: '+1 (USA)' },
+        { value: 'CAN', viewValue: '+1 (CAN)' },
+        { value: 'KZ', viewValue: '+7 (KZ)' },
+        { value: 'FRA', viewValue: '+33 (FRA)' },
     ];
 
     constructor(pxbAuthConfig: PxbAuthConfig) {
@@ -117,21 +126,20 @@ export class AuthComponent {
     initCreateAccountFormControls(): void {
         this.countryFormControl = new FormControl('', Validators.required);
         this.phoneNumberFormControl = new FormControl('');
-        this.emergencyFormControl = new FormControl('', Validators.required);
+        this.jobTitleFromControl = new FormControl('', Validators.required);
         this.accountDetails = [
-            undefined,
             {
                 form: this.accountDetailsPage1,
                 formControls: new Map([
                     ['country', this.countryFormControl],
                     ['phoneNumber', this.phoneNumberFormControl],
                 ]),
-                isValid: () => this.countryFormControl.value,
+                isValid: () => this.countryFormControl.value && this.phoneNumberFormControl.value
             },
             {
                 form: this.accountDetailsPage2,
-                formControls: new Map([['emergencyContact', this.emergencyFormControl]]),
-                isValid: () => this.emergencyFormControl.value,
+                formControls: new Map([['jobTitle', this.jobTitleFromControl]]),
+                isValid: () => this.jobTitleFromControl.value,
             },
         ];
     }

--- a/login-workflow/example/src/app/pages/auth/auth.component.ts
+++ b/login-workflow/example/src/app/pages/auth/auth.component.ts
@@ -45,7 +45,7 @@ import { MatFormField } from '@angular/material/form-field';
                 <mat-form-field appearance="fill">
                     <mat-label>Phone Number (optional)</mat-label>
                     <input matInput [formControl]="phoneNumberFormControl"
-                           (keyup.enter)="createAccount.canContinue() ? createAccount.goNext() : ''"/>
+                           (keyup.enter)="createAccountVC.attemptContinue()"/>
                 </mat-form-field>
             </form>
         </ng-template>
@@ -54,7 +54,7 @@ import { MatFormField } from '@angular/material/form-field';
             <form>
                 <mat-form-field appearance="fill">
                     <mat-label>Emergency Contact Number</mat-label>
-                    <input matInput [formControl]="emergencyFormControl" required />
+                    <input matInput [formControl]="emergencyFormControl" required (keyup.enter)="createAccountVC.attemptContinue()" />
                     <mat-error *ngIf="emergencyFormControl.hasError('required')">
                         Emergency Contact is <strong>required</strong>
                     </mat-error>

--- a/login-workflow/example/src/app/pages/auth/auth.component.ts
+++ b/login-workflow/example/src/app/pages/auth/auth.component.ts
@@ -1,7 +1,13 @@
 import { Component, TemplateRef, ViewChild } from '@angular/core';
 import { AbstractControl, FormControl, ValidatorFn, Validators } from '@angular/forms';
 import { MatFormField } from '@angular/material/form-field';
-import { AccountDetails, AUTH_ROUTES, PxbAuthConfig, PxbCreateAccountComponent, PxbCreateAccountInviteComponent } from '@pxblue/angular-auth-workflow';
+import {
+    AccountDetails,
+    AUTH_ROUTES,
+    PxbAuthConfig,
+    PxbCreateAccountComponent,
+    PxbCreateAccountInviteComponent,
+} from '@pxblue/angular-auth-workflow';
 
 @Component({
     selector: 'app-auth',
@@ -25,37 +31,40 @@ import { AccountDetails, AUTH_ROUTES, PxbAuthConfig, PxbCreateAccountComponent, 
 
         <!-- Custom Create Account page -->
         <ng-template #createAccountViaInvitePage>
-            <pxb-create-account-invite #createAccountInviteVC [accountDetails]="accountDetails"></pxb-create-account-invite>
+            <pxb-create-account-invite
+                #createAccountInviteVC
+                [accountDetails]="accountDetails"
+            ></pxb-create-account-invite>
         </ng-template>
 
         <!-- This is an example of a custom account details form.  To enable the defaults, remove this template and the accountDetails[]. -->
         <ng-template #accountDetailsPage1>
             <form>
-              <div style="display: flex;">
-                <mat-form-field appearance="fill"  [style.maxWidth.px]="170">
-                  <mat-label>Country Code</mat-label>
-                  <mat-select [formControl]="countryFormControl" required>
-                    <mat-option *ngFor="let country of countries" [value]="country.value">
-                      {{ country.viewValue }}
-                    </mat-option>
-                  </mat-select>
-                  <mat-error *ngIf="countryFormControl.hasError('required')">
-                    Code is <strong>required</strong>
-                  </mat-error>
-                </mat-form-field >
-                  <mat-form-field appearance="fill" [style.marginLeft.px]="16">
-                      <mat-label>Phone Number</mat-label>
-                      <input
-                          matInput
-                          required
-                          [formControl]="phoneNumberFormControl"
-                          (keyup.enter)="attemptGoNext()"
-                      />
+                <div style="display: flex;">
+                    <mat-form-field appearance="fill" [style.maxWidth.px]="170">
+                        <mat-label>Country Code</mat-label>
+                        <mat-select [formControl]="countryFormControl" required>
+                            <mat-option *ngFor="let country of countries" [value]="country.value">
+                                {{ country.viewValue }}
+                            </mat-option>
+                        </mat-select>
+                        <mat-error *ngIf="countryFormControl.hasError('required')">
+                            Code is <strong>required</strong>
+                        </mat-error>
+                    </mat-form-field>
+                    <mat-form-field appearance="fill" [style.marginLeft.px]="16">
+                        <mat-label>Phone Number</mat-label>
+                        <input
+                            matInput
+                            required
+                            [formControl]="phoneNumberFormControl"
+                            (keyup.enter)="attemptGoNext()"
+                        />
 
-                    <mat-error *ngIf="phoneNumberFormControl.hasError('required')">
-                      Code is <strong>required</strong>
-                    </mat-error>
-                  </mat-form-field>
+                        <mat-error *ngIf="phoneNumberFormControl.hasError('required')">
+                            Code is <strong>required</strong>
+                        </mat-error>
+                    </mat-form-field>
                 </div>
             </form>
         </ng-template>
@@ -64,12 +73,7 @@ import { AccountDetails, AUTH_ROUTES, PxbAuthConfig, PxbCreateAccountComponent, 
             <form>
                 <mat-form-field appearance="fill">
                     <mat-label>Job Title</mat-label>
-                    <input
-                        matInput
-                        [formControl]="jobTitleFromControl"
-                        required
-                        (keyup.enter)="attemptGoNext()"
-                    />
+                    <input matInput [formControl]="jobTitleFromControl" required (keyup.enter)="attemptGoNext()" />
                     <mat-error *ngIf="jobTitleFromControl.hasError('required')">
                         Job Title is <strong>required</strong>
                     </mat-error>
@@ -91,8 +95,8 @@ export class AuthComponent {
     jobTitleFromControl: FormControl;
     accountDetails: AccountDetails[];
 
-  @ViewChild('createAccountVC') createAccountVC: PxbCreateAccountComponent;
-  @ViewChild('createAccountInviteVC') createAccountInviteVC: PxbCreateAccountInviteComponent;
+    @ViewChild('createAccountVC') createAccountVC: PxbCreateAccountComponent;
+    @ViewChild('createAccountInviteVC') createAccountInviteVC: PxbCreateAccountInviteComponent;
 
     @ViewChild('accountDetailsPage1') accountDetailsPage1: TemplateRef<MatFormField>;
     @ViewChild('accountDetailsPage2') accountDetailsPage2: TemplateRef<MatFormField>;
@@ -134,7 +138,7 @@ export class AuthComponent {
                     ['country', this.countryFormControl],
                     ['phoneNumber', this.phoneNumberFormControl],
                 ]),
-                isValid: () => this.countryFormControl.value && this.phoneNumberFormControl.value
+                isValid: () => this.countryFormControl.value && this.phoneNumberFormControl.value,
             },
             {
                 form: this.accountDetailsPage2,
@@ -154,11 +158,11 @@ export class AuthComponent {
     }
 
     attemptGoNext(): void {
-      if (this.createAccountInviteVC) {
-        this.createAccountInviteVC.attemptContinue();
-      }
-      if (this.createAccountVC) {
-        this.createAccountVC.attemptContinue();
-      }
+        if (this.createAccountInviteVC) {
+            this.createAccountInviteVC.attemptContinue();
+        }
+        if (this.createAccountVC) {
+            this.createAccountVC.attemptContinue();
+        }
     }
 }

--- a/login-workflow/example/src/app/pages/auth/auth.component.ts
+++ b/login-workflow/example/src/app/pages/auth/auth.component.ts
@@ -1,6 +1,6 @@
 import { Component } from '@angular/core';
 import { AbstractControl, FormControl, ValidatorFn, Validators } from '@angular/forms';
-import { PxbAuthConfig, AUTH_ROUTES } from '@pxblue/angular-auth-workflow';
+import { PxbAuthConfig, AUTH_ROUTES, AccountDetails } from '@pxblue/angular-auth-workflow';
 
 @Component({
     selector: 'app-auth',
@@ -19,19 +19,18 @@ import { PxbAuthConfig, AUTH_ROUTES } from '@pxblue/angular-auth-workflow';
 
       <!-- Custom Create Account page -->
       <ng-template #createAccountPage>
-        <pxb-create-account
-          [accountDetailsPage2]="accountDetails"
-          [hasValidAccountDetailsPage2]="accountDetailsValid()">
+        <pxb-create-account [accountDetails]="infinity">
+          <template pxb-account-details-form-page-1 [ngTemplateOutlet]="accountDetailsRef"></template>
           <template pxb-account-details-form-page-2 [ngTemplateOutlet]="accountDetailsRef"></template>
         </pxb-create-account>
       </ng-template>
 
-      <!-- Custom Create Account via Invite page -->
+
+      <!-- Custom Create Account page -->
       <ng-template #createAccountViaInvitePage>
-        <pxb-create-account-invite
-          [accountDetailsPage1]="accountDetails"
-          [hasValidAccountDetailsPage1]="accountDetailsValid()">
+        <pxb-create-account-invite [accountDetails]="infinity">
           <template pxb-account-details-form-page-1 [ngTemplateOutlet]="accountDetailsRef"></template>
+          <template pxb-account-details-form-page-2 [ngTemplateOutlet]="accountDetailsRef"></template>
         </pxb-create-account-invite>
       </ng-template>
 
@@ -66,6 +65,7 @@ export class AuthComponent {
     countryFormControl: FormControl;
     phoneNumberFormControl: FormControl;
     accountDetails: FormControl[];
+    infinity: AccountDetails[];
 
     countries: any[] = [
         { value: 'US', viewValue: 'US' },
@@ -89,6 +89,16 @@ export class AuthComponent {
 
     ngOnInit(): void {
         this.initCreateAccountFormControls();
+        this.infinity = [
+          {
+            forms: [this.countryFormControl, this.phoneNumberFormControl],
+            isValid: () => this.countryFormControl.value
+          },
+          {
+            forms: [this.countryFormControl, this.phoneNumberFormControl],
+            isValid: () => this.phoneNumberFormControl.value
+          }
+        ]
     }
 
      initCreateAccountFormControls(): void {

--- a/login-workflow/example/src/app/pages/auth/auth.component.ts
+++ b/login-workflow/example/src/app/pages/auth/auth.component.ts
@@ -5,78 +5,79 @@ import { PxbAuthConfig, AUTH_ROUTES, AccountDetails } from '@pxblue/angular-auth
 @Component({
     selector: 'app-auth',
     template: `
-      <!-- Project-specific login page -->
-      <ng-template #loginPage>
-        <pxb-login [customEmailValidator]="customValidator()">
-          <div pxb-login-header>
-            <img src="assets/images/eaton_stacked_logo.png" style="max-width: 100%; max-height: 80px;"/>
-          </div>
-          <div pxb-login-footer style="text-align: center;">
-            <img src="assets/images/cybersecurity_certified.png" style="max-width: 30%; align-self: center;"/>
-          </div>
-        </pxb-login>
-      </ng-template>
+        <!-- Project-specific login page -->
+        <ng-template #loginPage>
+            <pxb-login [customEmailValidator]="customValidator()">
+                <div pxb-login-header>
+                    <img src="assets/images/eaton_stacked_logo.png" style="max-width: 100%; max-height: 80px;" />
+                </div>
+                <div pxb-login-footer style="text-align: center;">
+                    <img src="assets/images/cybersecurity_certified.png" style="max-width: 30%; align-self: center;" />
+                </div>
+            </pxb-login>
+        </ng-template>
 
-      <!-- Custom Create Account page -->
-      <ng-template #createAccountPage>
-        <pxb-create-account [accountDetails]="accountDetails">
-          <template pxb-account-details-page-0 [ngTemplateOutlet]="accountDetailsFirstPage"></template>
-          <template pxb-account-details-page-1 [ngTemplateOutlet]="accountDetailsSecondPage"></template>
-        </pxb-create-account>
-      </ng-template>
+        <!-- Custom Create Account page -->
+        <ng-template #createAccountPage>
+            <pxb-create-account [accountDetails]="accountDetails">
+                <template pxb-account-details-page-0 [ngTemplateOutlet]="accountDetailsFirstPage"></template>
+                <template pxb-account-details-page-1 [ngTemplateOutlet]="accountDetailsSecondPage"></template>
+            </pxb-create-account>
+        </ng-template>
 
+        <!-- Custom Create Account page -->
+        <ng-template #createAccountViaInvitePage>
+            <pxb-create-account-invite [accountDetails]="accountDetails">
+                <template pxb-account-details-page-0 [ngTemplateOutlet]="accountDetailsFirstPage"></template>
+                <template pxb-account-details-page-1 [ngTemplateOutlet]="accountDetailsSecondPage"></template>
+            </pxb-create-account-invite>
+        </ng-template>
 
-      <!-- Custom Create Account page -->
-      <ng-template #createAccountViaInvitePage>
-        <pxb-create-account-invite [accountDetails]="accountDetails">
-          <template pxb-account-details-page-0 [ngTemplateOutlet]="accountDetailsFirstPage"></template>
-          <template pxb-account-details-page-1 [ngTemplateOutlet]="accountDetailsSecondPage"></template>
-        </pxb-create-account-invite>
-      </ng-template>
+        <!-- This is an example of a custom account details form.  To enable the defaults, remove this template and the accountDetails[]. -->
+        <ng-template #accountDetailsFirstPage>
+            <form>
+                <mat-form-field appearance="fill" [style.width.%]="100" [style.marginBottom.px]="8">
+                    <mat-label>Country</mat-label>
+                    <mat-select [formControl]="countryFormControl" required>
+                        <mat-option *ngFor="let country of countries" [value]="country.value">
+                            {{ country.viewValue }}
+                        </mat-option>
+                    </mat-select>
+                    <mat-error *ngIf="countryFormControl.hasError('required')">
+                        Country is <strong>required</strong>
+                    </mat-error>
+                </mat-form-field>
+                <mat-form-field appearance="fill" [style.width.%]="100" [style.marginBottom.px]="8">
+                    <mat-label>Phone Number (optional)</mat-label>
+                    <input matInput [formControl]="phoneNumberFormControl" />
+                </mat-form-field>
+            </form>
+        </ng-template>
 
-      <!-- This is an example of a custom account details form.  To enable the defaults, remove this template and the accountDetails[]. -->
-      <ng-template #accountDetailsFirstPage>
-        <form>
-          <mat-form-field appearance="fill" [style.width.%]="100" [style.marginBottom.px]="8">
-            <mat-label>Country</mat-label>
-            <mat-select [formControl]="countryFormControl" required>
-              <mat-option *ngFor="let country of countries" [value]="country.value">
-                {{ country.viewValue }}
-              </mat-option>
-            </mat-select>
-            <mat-error *ngIf="countryFormControl.hasError('required')">
-              Country is <strong>required</strong>
-            </mat-error>
-          </mat-form-field>
-          <mat-form-field appearance="fill" [style.width.%]="100" [style.marginBottom.px]="8">
-            <mat-label>Phone Number (optional)</mat-label>
-            <input matInput [formControl]="phoneNumberFormControl"/>
-          </mat-form-field>
-        </form>
-      </ng-template>
+        <ng-template #accountDetailsSecondPage>
+            <form>
+                <mat-form-field appearance="fill" [style.width.%]="100" [style.marginBottom.px]="8">
+                    <mat-label>Emergency Contact Number</mat-label>
+                    <input matInput [formControl]="emergencyFormControl" required />
+                    <mat-error *ngIf="emergencyFormControl.hasError('required')">
+                        Emergency Contact is <strong>required</strong>
+                    </mat-error>
+                </mat-form-field>
+            </form>
+        </ng-template>
 
-      <ng-template #accountDetailsSecondPage>
-        <form>
-          <mat-form-field appearance="fill" [style.width.%]="100" [style.marginBottom.px]="8">
-            <mat-label>Emergency Contact Number</mat-label>
-            <input matInput [formControl]="emergencyFormControl" required />
-            <mat-error *ngIf="emergencyFormControl.hasError('required')">
-              Emergency Contact is <strong>required</strong>
-            </mat-error>
-          </mat-form-field>
-        </form>
-      </ng-template>
-
-      <!-- This is what accepts all page customizations and renders on screen. !-->
-      <pxb-auth [loginRef]="loginPage"
-                [createAccountRef]="createAccountPage"
-                [createAccountInviteRef]="createAccountViaInvitePage"></pxb-auth>
+        <!-- This is what accepts all page customizations and renders on screen. !-->
+        <pxb-auth
+            [loginRef]="loginPage"
+            [createAccountRef]="createAccountPage"
+            [createAccountInviteRef]="createAccountViaInvitePage"
+        ></pxb-auth>
     `,
 })
 export class AuthComponent {
     countryFormControl: FormControl;
     phoneNumberFormControl: FormControl;
-  emergencyFormControl: FormControl;
+    emergencyFormControl: FormControl;
     accountDetails: AccountDetails[];
 
     countries: any[] = [
@@ -103,21 +104,21 @@ export class AuthComponent {
         this.initCreateAccountFormControls();
     }
 
-     initCreateAccountFormControls(): void {
-         this.countryFormControl = new FormControl('', Validators.required);
-         this.phoneNumberFormControl = new FormControl('');
-         this.emergencyFormControl = new FormControl('', Validators.required);
-         this.accountDetails = [
-           {
-             formControls: [this.countryFormControl, this.phoneNumberFormControl],
-             isValid: () => this.countryFormControl.value
-           },
-           {
-             formControls: [this.emergencyFormControl],
-             isValid: () => this.emergencyFormControl.value
-           }
-         ]
-     }
+    initCreateAccountFormControls(): void {
+        this.countryFormControl = new FormControl('', Validators.required);
+        this.phoneNumberFormControl = new FormControl('');
+        this.emergencyFormControl = new FormControl('', Validators.required);
+        this.accountDetails = [
+            {
+                formControls: [this.countryFormControl, this.phoneNumberFormControl],
+                isValid: () => this.countryFormControl.value,
+            },
+            {
+                formControls: [this.emergencyFormControl],
+                isValid: () => this.emergencyFormControl.value,
+            },
+        ];
+    }
 
     customValidator(): ValidatorFn {
         return (control: AbstractControl): { [key: string]: any } | null => {

--- a/login-workflow/example/src/app/pages/auth/auth.component.ts
+++ b/login-workflow/example/src/app/pages/auth/auth.component.ts
@@ -1,7 +1,7 @@
-import {Component, Input, TemplateRef, ViewChild} from '@angular/core';
-import {AbstractControl, Form, FormControl, ValidatorFn, Validators} from '@angular/forms';
+import { Component, Input, TemplateRef, ViewChild } from '@angular/core';
+import { AbstractControl, Form, FormControl, ValidatorFn, Validators } from '@angular/forms';
 import { PxbAuthConfig, AUTH_ROUTES, AccountDetails } from '@pxblue/angular-auth-workflow';
-import {MatFormField} from "@angular/material/form-field";
+import { MatFormField } from '@angular/material/form-field';
 
 @Component({
     selector: 'app-auth',
@@ -107,16 +107,13 @@ export class AuthComponent {
         this.phoneNumberFormControl = new FormControl('');
         this.emergencyFormControl = new FormControl('', Validators.required);
         this.accountDetails = [
-          {
-            form: undefined, formControls: undefined, isValid: () => true,
-          },
             {
-              form: this.accountDetailsPage1,
+                form: this.accountDetailsPage1,
                 formControls: [this.countryFormControl, this.phoneNumberFormControl],
                 isValid: () => this.countryFormControl.value,
             },
             {
-              form: this.accountDetailsPage2,
+                form: this.accountDetailsPage2,
                 formControls: [this.emergencyFormControl],
                 isValid: () => this.emergencyFormControl.value,
             },

--- a/login-workflow/example/src/app/pages/auth/auth.component.ts
+++ b/login-workflow/example/src/app/pages/auth/auth.component.ts
@@ -1,6 +1,6 @@
 import { Component, Input, TemplateRef, ViewChild } from '@angular/core';
 import { AbstractControl, Form, FormControl, ValidatorFn, Validators } from '@angular/forms';
-import { PxbAuthConfig, AUTH_ROUTES, AccountDetails } from '@pxblue/angular-auth-workflow';
+import { PxbAuthConfig, AUTH_ROUTES, AccountDetails, PxbCreateAccountComponent } from '@pxblue/angular-auth-workflow';
 import { MatFormField } from '@angular/material/form-field';
 
 @Component({
@@ -20,7 +20,7 @@ import { MatFormField } from '@angular/material/form-field';
 
         <!-- Custom Create Account page -->
         <ng-template #createAccountPage>
-            <pxb-create-account [accountDetails]="accountDetails"></pxb-create-account>
+            <pxb-create-account #createAccount [accountDetails]="accountDetails"></pxb-create-account>
         </ng-template>
 
         <!-- Custom Create Account page -->
@@ -44,7 +44,8 @@ import { MatFormField } from '@angular/material/form-field';
                 </mat-form-field>
                 <mat-form-field appearance="fill" [style.width.%]="100" [style.marginBottom.px]="8">
                     <mat-label>Phone Number (optional)</mat-label>
-                    <input matInput [formControl]="phoneNumberFormControl" />
+                    <input matInput [formControl]="phoneNumberFormControl"
+                           (keyup.enter)="createAccount.canContinue() ? createAccount.goNext() : ''"/>
                 </mat-form-field>
             </form>
         </ng-template>
@@ -77,6 +78,7 @@ export class AuthComponent {
 
     @ViewChild('accountDetailsPage1') accountDetailsPage1: TemplateRef<MatFormField>;
     @ViewChild('accountDetailsPage2') accountDetailsPage2: TemplateRef<MatFormField>;
+    @ViewChild('createAccount') createAccount: PxbCreateAccountComponent;
 
     countries: any[] = [
         { value: 'US', viewValue: 'US' },

--- a/login-workflow/example/src/app/pages/auth/auth.component.ts
+++ b/login-workflow/example/src/app/pages/auth/auth.component.ts
@@ -5,83 +5,64 @@ import { PxbAuthConfig, AUTH_ROUTES } from '@pxblue/angular-auth-workflow';
 @Component({
     selector: 'app-auth',
     template: `
-        <!-- Project-specific login page -->
-        <ng-template #loginPage>
-            <pxb-login [customEmailValidator]="customValidator()">
-                <div pxb-login-header>
-                    <img src="assets/images/eaton_stacked_logo.png" style="max-width: 100%; max-height: 80px;" />
-                </div>
-                <div pxb-login-footer style="text-align: center;">
-                    <img src="assets/images/cybersecurity_certified.png" style="max-width: 30%; align-self: center;" />
-                </div>
-            </pxb-login>
-        </ng-template>
+      <!-- Project-specific login page -->
+      <ng-template #loginPage>
+        <pxb-login [customEmailValidator]="customValidator()">
+          <div pxb-login-header>
+            <img src="assets/images/eaton_stacked_logo.png" style="max-width: 100%; max-height: 80px;"/>
+          </div>
+          <div pxb-login-footer style="text-align: center;">
+            <img src="assets/images/cybersecurity_certified.png" style="max-width: 30%; align-self: center;"/>
+          </div>
+        </pxb-login>
+      </ng-template>
 
-        <!-- Custom Create Account page -->
-        <!-- <ng-template #createAccountPage>
-            <pxb-create-account
-                [accountDetails]="accountDetails"
-                [hasValidAccountDetails]="accountDetailsValid()"
-                [userName]="firstNameFormControl.value + ' ' + lastNameFormControl.value"
-            >
-                <template pxb-account-details-form [ngTemplateOutlet]="accountDetailsRef"></template>
-            </pxb-create-account>
-        </ng-template> -->
+      <!-- Custom Create Account page -->
+      <ng-template #createAccountPage>
+        <pxb-create-account
+          [accountDetailsPage2]="accountDetails"
+          [hasValidAccountDetailsPage2]="accountDetailsValid()">
+          <template pxb-account-details-form-page-2 [ngTemplateOutlet]="accountDetailsRef"></template>
+        </pxb-create-account>
+      </ng-template>
 
-        <!-- Custom Create Account via Invite page -->
-        <!-- <ng-template #createAccountViaInvitePage>
-            <pxb-create-account-invite
-                [accountDetails]="accountDetails"
-                [hasValidAccountDetails]="accountDetailsValid()"
-                [userName]="firstNameFormControl.value + ' ' + lastNameFormControl.value"
-            >
-                <template pxb-account-details-form [ngTemplateOutlet]="accountDetailsRef"></template>
-            </pxb-create-account-invite>
-        </ng-template> -->
+      <!-- Custom Create Account via Invite page -->
+      <ng-template #createAccountViaInvitePage>
+        <pxb-create-account-invite
+          [accountDetailsPage1]="accountDetails"
+          [hasValidAccountDetailsPage1]="accountDetailsValid()">
+          <template pxb-account-details-form-page-1 [ngTemplateOutlet]="accountDetailsRef"></template>
+        </pxb-create-account-invite>
+      </ng-template>
 
-        <!-- This is an example of a custom account details form.  To enable the defaults, remove this template and the accountDetails[]. -->
-        <!-- <ng-template #accountDetailsRef>
-            <form>
-                <mat-form-field appearance="fill" [style.width.%]="100" [style.marginBottom.px]="8">
-                    <mat-label>First Name</mat-label>
-                    <input matInput [formControl]="firstNameFormControl" required />
-                    <mat-error *ngIf="firstNameFormControl.hasError('required')">
-                        First Name is <strong>required</strong>
-                    </mat-error>
-                </mat-form-field>
-                <mat-form-field appearance="fill" [style.width.%]="100" [style.marginBottom.px]="8">
-                    <mat-label>Last Name</mat-label>
-                    <input matInput [formControl]="lastNameFormControl" required />
-                    <mat-error *ngIf="lastNameFormControl.hasError('required')">
-                        Last Name is <strong>required</strong>
-                    </mat-error>
-                </mat-form-field>
-                <mat-form-field appearance="fill" [style.width.%]="100" [style.marginBottom.px]="8">
-                    <mat-label>Country</mat-label>
-                    <mat-select [formControl]="countryFormControl" required>
-                        <mat-option *ngFor="let country of countries" [value]="country.value">
-                            {{ country.viewValue }}
-                        </mat-option>
-                    </mat-select>
-                    <mat-error *ngIf="countryFormControl.hasError('required')">
-                        Country is <strong>required</strong>
-                    </mat-error>
-                </mat-form-field>
-                <mat-form-field appearance="fill" [style.width.%]="100" [style.marginBottom.px]="8">
-                    <mat-label>Phone Number (optional)</mat-label>
-                    <input matInput [formControl]="phoneNumberFormControl" />
-                </mat-form-field>
-            </form>
-        </ng-template> -->
+      <!-- This is an example of a custom account details form.  To enable the defaults, remove this template and the accountDetails[]. -->
+      <ng-template #accountDetailsRef>
+        <form>
+          <mat-form-field appearance="fill" [style.width.%]="100" [style.marginBottom.px]="8">
+            <mat-label>Country</mat-label>
+            <mat-select [formControl]="countryFormControl" required>
+              <mat-option *ngFor="let country of countries" [value]="country.value">
+                {{ country.viewValue }}
+              </mat-option>
+            </mat-select>
+            <mat-error *ngIf="countryFormControl.hasError('required')">
+              Country is <strong>required</strong>
+            </mat-error>
+          </mat-form-field>
+          <mat-form-field appearance="fill" [style.width.%]="100" [style.marginBottom.px]="8">
+            <mat-label>Phone Number (optional)</mat-label>
+            <input matInput [formControl]="phoneNumberFormControl"/>
+          </mat-form-field>
+        </form>
+      </ng-template>
 
-        <!-- This is what accepts all page customizations and renders on screen. !-->
-        <pxb-auth [loginRef]="loginPage">
-        </pxb-auth>
+      <!-- This is what accepts all page customizations and renders on screen. !-->
+      <pxb-auth [loginRef]="loginPage"
+                [createAccountRef]="createAccountPage"
+                [createAccountInviteRef]="createAccountViaInvitePage"></pxb-auth>
     `,
 })
 export class AuthComponent {
-    firstNameFormControl: FormControl;
-    lastNameFormControl: FormControl;
     countryFormControl: FormControl;
     phoneNumberFormControl: FormControl;
     accountDetails: FormControl[];
@@ -107,32 +88,24 @@ export class AuthComponent {
     }
 
     ngOnInit(): void {
-        // this.initCreateAccountFormControls();
+        this.initCreateAccountFormControls();
     }
 
-    // initCreateAccountFormControls(): void {
-    //     this.firstNameFormControl = new FormControl('', Validators.required);
-    //     this.lastNameFormControl = new FormControl('', Validators.required);
-    //     this.countryFormControl = new FormControl('', Validators.required);
-    //     this.phoneNumberFormControl = new FormControl('');
-    //     this.accountDetails = [
-    //         this.firstNameFormControl,
-    //         this.lastNameFormControl,
-    //         this.countryFormControl,
-    //         this.phoneNumberFormControl,
-    //     ];
-    // }
+     initCreateAccountFormControls(): void {
+         this.countryFormControl = new FormControl('', Validators.required);
+         this.phoneNumberFormControl = new FormControl('');
+         this.accountDetails = [
+             this.countryFormControl,
+             this.phoneNumberFormControl,
+         ];
+     }
 
-    // accountDetailsValid(): boolean {
-    //     return (
-    //         this.firstNameFormControl.value &&
-    //         this.firstNameFormControl.valid &&
-    //         this.lastNameFormControl.value &&
-    //         this.lastNameFormControl.valid &&
-    //         this.countryFormControl.value &&
-    //         this.countryFormControl.valid
-    //     );
-    // }
+     accountDetailsValid(): boolean {
+         return (
+             this.countryFormControl.value &&
+             this.countryFormControl.valid
+         );
+     }
 
     customValidator(): ValidatorFn {
         return (control: AbstractControl): { [key: string]: any } | null => {

--- a/login-workflow/example/src/app/pages/auth/auth.component.ts
+++ b/login-workflow/example/src/app/pages/auth/auth.component.ts
@@ -19,23 +19,23 @@ import { PxbAuthConfig, AUTH_ROUTES, AccountDetails } from '@pxblue/angular-auth
 
       <!-- Custom Create Account page -->
       <ng-template #createAccountPage>
-        <pxb-create-account [accountDetails]="infinity">
-          <template pxb-account-details-form-page-1 [ngTemplateOutlet]="accountDetailsRef"></template>
-          <template pxb-account-details-form-page-2 [ngTemplateOutlet]="accountDetailsRef"></template>
+        <pxb-create-account [accountDetails]="accountDetails">
+          <template pxb-account-details-form-page-1 [ngTemplateOutlet]="accountDetailsPage1"></template>
+          <template pxb-account-details-form-page-2 [ngTemplateOutlet]="accountDetailsPage2"></template>
         </pxb-create-account>
       </ng-template>
 
 
       <!-- Custom Create Account page -->
       <ng-template #createAccountViaInvitePage>
-        <pxb-create-account-invite [accountDetails]="infinity">
-          <template pxb-account-details-form-page-1 [ngTemplateOutlet]="accountDetailsRef"></template>
-          <template pxb-account-details-form-page-2 [ngTemplateOutlet]="accountDetailsRef"></template>
+        <pxb-create-account-invite [accountDetails]="accountDetails">
+          <template pxb-account-details-form-page-1 [ngTemplateOutlet]="accountDetailsPage1"></template>
+          <template pxb-account-details-form-page-2 [ngTemplateOutlet]="accountDetailsPage2"></template>
         </pxb-create-account-invite>
       </ng-template>
 
       <!-- This is an example of a custom account details form.  To enable the defaults, remove this template and the accountDetails[]. -->
-      <ng-template #accountDetailsRef>
+      <ng-template #accountDetailsPage1>
         <form>
           <mat-form-field appearance="fill" [style.width.%]="100" [style.marginBottom.px]="8">
             <mat-label>Country</mat-label>
@@ -54,6 +54,17 @@ import { PxbAuthConfig, AUTH_ROUTES, AccountDetails } from '@pxblue/angular-auth
           </mat-form-field>
         </form>
       </ng-template>
+      <ng-template #accountDetailsPage2>
+        <form>
+          <mat-form-field appearance="fill" [style.width.%]="100" [style.marginBottom.px]="8">
+            <mat-label>Emergency Contact Number</mat-label>
+            <input matInput [formControl]="emergencyFormControl" required />
+            <mat-error *ngIf="emergencyFormControl.hasError('required')">
+              Emergency Contact is <strong>required</strong>
+            </mat-error>
+          </mat-form-field>
+        </form>
+      </ng-template>
 
       <!-- This is what accepts all page customizations and renders on screen. !-->
       <pxb-auth [loginRef]="loginPage"
@@ -64,8 +75,8 @@ import { PxbAuthConfig, AUTH_ROUTES, AccountDetails } from '@pxblue/angular-auth
 export class AuthComponent {
     countryFormControl: FormControl;
     phoneNumberFormControl: FormControl;
-    accountDetails: FormControl[];
-    infinity: AccountDetails[];
+  emergencyFormControl: FormControl;
+    accountDetails: AccountDetails[];
 
     countries: any[] = [
         { value: 'US', viewValue: 'US' },
@@ -89,32 +100,22 @@ export class AuthComponent {
 
     ngOnInit(): void {
         this.initCreateAccountFormControls();
-        this.infinity = [
-          {
-            forms: [this.countryFormControl, this.phoneNumberFormControl],
-            isValid: () => this.countryFormControl.value
-          },
-          {
-            forms: [this.countryFormControl, this.phoneNumberFormControl],
-            isValid: () => this.phoneNumberFormControl.value
-          }
-        ]
     }
 
      initCreateAccountFormControls(): void {
          this.countryFormControl = new FormControl('', Validators.required);
          this.phoneNumberFormControl = new FormControl('');
+         this.emergencyFormControl = new FormControl('', Validators.required);
          this.accountDetails = [
-             this.countryFormControl,
-             this.phoneNumberFormControl,
-         ];
-     }
-
-     accountDetailsValid(): boolean {
-         return (
-             this.countryFormControl.value &&
-             this.countryFormControl.valid
-         );
+           {
+             formControls: [this.countryFormControl, this.phoneNumberFormControl],
+             isValid: () => this.countryFormControl.value
+           },
+           {
+             formControls: [this.emergencyFormControl],
+             isValid: () => this.emergencyFormControl.value
+           }
+         ]
      }
 
     customValidator(): ValidatorFn {

--- a/login-workflow/example/src/app/pages/auth/auth.component.ts
+++ b/login-workflow/example/src/app/pages/auth/auth.component.ts
@@ -20,8 +20,8 @@ import { PxbAuthConfig, AUTH_ROUTES, AccountDetails } from '@pxblue/angular-auth
       <!-- Custom Create Account page -->
       <ng-template #createAccountPage>
         <pxb-create-account [accountDetails]="accountDetails">
-          <template pxb-account-details-form-page-1 [ngTemplateOutlet]="accountDetailsPage1"></template>
-          <template pxb-account-details-form-page-2 [ngTemplateOutlet]="accountDetailsPage2"></template>
+          <template pxb-account-details-page-0 [ngTemplateOutlet]="accountDetailsFirstPage"></template>
+          <template pxb-account-details-page-1 [ngTemplateOutlet]="accountDetailsSecondPage"></template>
         </pxb-create-account>
       </ng-template>
 
@@ -29,13 +29,13 @@ import { PxbAuthConfig, AUTH_ROUTES, AccountDetails } from '@pxblue/angular-auth
       <!-- Custom Create Account page -->
       <ng-template #createAccountViaInvitePage>
         <pxb-create-account-invite [accountDetails]="accountDetails">
-          <template pxb-account-details-form-page-1 [ngTemplateOutlet]="accountDetailsPage1"></template>
-          <template pxb-account-details-form-page-2 [ngTemplateOutlet]="accountDetailsPage2"></template>
+          <template pxb-account-details-page-0 [ngTemplateOutlet]="accountDetailsFirstPage"></template>
+          <template pxb-account-details-page-1 [ngTemplateOutlet]="accountDetailsSecondPage"></template>
         </pxb-create-account-invite>
       </ng-template>
 
       <!-- This is an example of a custom account details form.  To enable the defaults, remove this template and the accountDetails[]. -->
-      <ng-template #accountDetailsPage1>
+      <ng-template #accountDetailsFirstPage>
         <form>
           <mat-form-field appearance="fill" [style.width.%]="100" [style.marginBottom.px]="8">
             <mat-label>Country</mat-label>
@@ -54,7 +54,8 @@ import { PxbAuthConfig, AUTH_ROUTES, AccountDetails } from '@pxblue/angular-auth
           </mat-form-field>
         </form>
       </ng-template>
-      <ng-template #accountDetailsPage2>
+
+      <ng-template #accountDetailsSecondPage>
         <form>
           <mat-form-field appearance="fill" [style.width.%]="100" [style.marginBottom.px]="8">
             <mat-label>Emergency Contact Number</mat-label>

--- a/login-workflow/example/src/app/services/auth-ui.service.ts
+++ b/login-workflow/example/src/app/services/auth-ui.service.ts
@@ -84,7 +84,7 @@ export class AuthUIService implements IPxbAuthUIService {
         console.log(`Performing a sample verifyResetCode request with the following credentials:\n code: ${resetCode}`);
         return new Promise((resolve, reject) => {
             setTimeout(() => {
-                if (!resetCode || resetCode.toUpperCase() === 'INVALID_LINK' ||  resetCode.toUpperCase() === 'FAIL') {
+                if (!resetCode || resetCode.toUpperCase() === 'INVALID_LINK' || resetCode.toUpperCase() === 'FAIL') {
                     return reject();
                 }
                 return resolve();

--- a/login-workflow/example/src/app/services/register-ui.service.ts
+++ b/login-workflow/example/src/app/services/register-ui.service.ts
@@ -70,6 +70,8 @@ export class RegisterUIService implements IPxbRegisterUIService {
     }
 
     completeRegistration(
+        firstName: string,
+        lastName: string,
         formControls: FormControl[],
         password: string,
         validationCode?: string,
@@ -80,11 +82,8 @@ export class RegisterUIService implements IPxbRegisterUIService {
         if (!validationCode) {
             validationCode = urlCode;
         }
-        const firstName = formControls[0]?.value;
-        const lastName = formControls[1]?.value;
-        const phoneNumber = formControls[2]?.value;
         console.log(
-            `Performing a sample CompleteRegistration request with the following credentials:\n firstName: ${firstName}\n lastName: ${lastName}\n phoneNumber: ${phoneNumber}\n password: ${password}\n validationCode: ${validationCode}\n email: ${email}`
+            `Performing a sample CompleteRegistration request with the following credentials:\n firstName: ${firstName}\n lastName: ${lastName}\n password: ${password}\n validationCode: ${validationCode}\n email: ${email}`
         );
         return new Promise((resolve, reject) => {
             setTimeout(() => {

--- a/login-workflow/example/src/app/services/register-ui.service.ts
+++ b/login-workflow/example/src/app/services/register-ui.service.ts
@@ -72,7 +72,7 @@ export class RegisterUIService implements IPxbRegisterUIService {
     completeRegistration(
         firstName: string,
         lastName: string,
-        customAccountDetails: string[],
+        customAccountDetails: Map<string, FormControl>,
         password: string,
         validationCode?: string,
         email?: string
@@ -85,7 +85,10 @@ export class RegisterUIService implements IPxbRegisterUIService {
         console.log(
             `Performing a sample CompleteRegistration request with the following credentials:\n firstName: ${firstName}\n lastName: ${lastName}\n password: ${password}\n validationCode: ${validationCode}\n email: ${email}`
         );
-        console.log(`Custom account details: ${customAccountDetails.toString()}`);
+        console.log(`Custom account details:`);
+        for (const key of customAccountDetails.keys()) {
+            console.log(`${key}: ${customAccountDetails.get(key).value}`);
+        }
         return new Promise((resolve, reject) => {
             setTimeout(() => {
                 if (firstName && firstName.toUpperCase() === 'FAIL') {

--- a/login-workflow/example/src/app/services/register-ui.service.ts
+++ b/login-workflow/example/src/app/services/register-ui.service.ts
@@ -72,7 +72,7 @@ export class RegisterUIService implements IPxbRegisterUIService {
     completeRegistration(
         firstName: string,
         lastName: string,
-        formControls: FormControl[],
+        customAccountDetails: string[],
         password: string,
         validationCode?: string,
         email?: string
@@ -85,6 +85,7 @@ export class RegisterUIService implements IPxbRegisterUIService {
         console.log(
             `Performing a sample CompleteRegistration request with the following credentials:\n firstName: ${firstName}\n lastName: ${lastName}\n password: ${password}\n validationCode: ${validationCode}\n email: ${email}`
         );
+        console.log(`Custom account details: ${customAccountDetails.toString()}`);
         return new Promise((resolve, reject) => {
             setTimeout(() => {
                 if (firstName && firstName.toUpperCase() === 'FAIL') {

--- a/login-workflow/package.json
+++ b/login-workflow/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pxblue/angular-auth-workflow",
   "description": "Re-usable workflow components for Authentication and Registration within Eaton applications.",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "scripts": {
     "ng": "ng",
     "watch": "ng build -c demo",

--- a/login-workflow/src/pages/create-account-invite/create-account-invite.component.html
+++ b/login-workflow/src/pages/create-account-invite/create-account-invite.component.html
@@ -23,7 +23,7 @@
         *ngIf="registrationUtils.getCurrentPage() === 1"
         [(password)]="password"
         [(passwordMeetsRequirements)]="passwordMeetsRequirements"
-        (advance)="canContinue() ? goNext() : ''"
+        (advance)="attemptContinue()"
     ></pxb-create-account-create-password-step>
 
     <!-- Page 1 -->
@@ -33,7 +33,7 @@
         [(firstName)]="firstName"
         [(lastName)]="lastName"
         (accountNameValid)="validAccountName = $event"
-        (advance)="canContinue() ? goNext() : ''"
+        (advance)="attemptContinue()"
     >
         <template
             pxb-account-details

--- a/login-workflow/src/pages/create-account-invite/create-account-invite.component.html
+++ b/login-workflow/src/pages/create-account-invite/create-account-invite.component.html
@@ -27,17 +27,26 @@
     ></pxb-create-account-create-password-step>
 
     <pxb-create-account-account-details-step
-        *ngIf="currentPageId === 2 && !skipAccountDetails()"
-        [useDefaultAccountDetails]="useDefaultAccountDetails"
-        (accountDetailsChange)="accountDetails = $event"
-        (validAccountDetailsChange)="hasValidAccountDetails = $event"
+        *ngIf="currentPageId === 2"
+        [showDefaultAccountDetails]="true"
+        (firstName)="firstName = $event"
+        (lastName)="lastName = $event"
+        (accountNameValid)="validAccountName = $event"
         (advance)="canContinue() ? goNext() : ''"
     >
-        <ng-content pxb-account-details-form select="[pxb-account-details-form]"></ng-content>
+        <ng-content pxb-account-details-form select="[pxb-account-details-form-page-1]"></ng-content>
+    </pxb-create-account-account-details-step>
+
+    <pxb-create-account-account-details-step
+        *ngIf="currentPageId === 3 && hasExtendedAccountDetails()"
+        [showDefaultAccountDetails]="false"
+        (advance)="canContinue() ? goNext() : ''"
+    >
+        <ng-content pxb-account-details-form select="[pxb-account-details-form-page-2]"></ng-content>
     </pxb-create-account-account-details-step>
 
     <pxb-create-account-account-created-step
-        *ngIf="currentPageId === 3 || (currentPageId === 2 && skipAccountDetails())"
+        *ngIf="(currentPageId === 3 && !hasExtendedAccountDetails()) || currentPageId === 4"
         [userName]="getUserName()"
     >
     </pxb-create-account-account-created-step>

--- a/login-workflow/src/pages/create-account-invite/create-account-invite.component.html
+++ b/login-workflow/src/pages/create-account-invite/create-account-invite.component.html
@@ -26,30 +26,37 @@
         (advance)="canContinue() ? goNext() : ''"
     ></pxb-create-account-create-password-step>
 
+    <!-- Page 1 -->
     <pxb-create-account-account-details-step
-        *ngIf="currentPageId === 2"
+        *ngIf="showAccountDetailPage(0)"
         [showDefaultAccountDetails]="true"
-        (firstName)="firstName = $event"
-        (lastName)="lastName = $event"
+        [(firstName)]="firstName"
+        [(lastName)]="lastName"
         (accountNameValid)="validAccountName = $event"
         (advance)="canContinue() ? goNext() : ''"
     >
         <ng-content pxb-account-details-form select="[pxb-account-details-form-page-1]"></ng-content>
     </pxb-create-account-account-details-step>
 
-    <pxb-create-account-account-details-step
-        *ngIf="currentPageId === 3 && hasExtendedAccountDetails()"
-        [showDefaultAccountDetails]="false"
-        (advance)="canContinue() ? goNext() : ''"
-    >
+    <!-- Page 2 -->
+    <pxb-create-account-account-details-step *ngIf="showAccountDetailPage(1)">
         <ng-content pxb-account-details-form select="[pxb-account-details-form-page-2]"></ng-content>
     </pxb-create-account-account-details-step>
 
+    <!-- Page 3 -->
+    <pxb-create-account-account-details-step *ngIf="showAccountDetailPage(2)">
+        <ng-content pxb-account-details-form select="[pxb-account-details-form-page-3]"></ng-content>
+    </pxb-create-account-account-details-step>
+
+    <!-- Page 4 -->
+    <pxb-create-account-account-details-step *ngIf="showAccountDetailPage(3)">
+        <ng-content pxb-account-details-form select="[pxb-account-details-form-page-4]"></ng-content>
+    </pxb-create-account-account-details-step>
+
     <pxb-create-account-account-created-step
-        *ngIf="(currentPageId === 3 && !hasExtendedAccountDetails()) || currentPageId === 4"
+        *ngIf="showAccountCreated()"
         [userName]="getUserName()"
-    >
-    </pxb-create-account-account-created-step>
+    ></pxb-create-account-account-created-step>
 
     <mat-divider class="pxb-auth-divider" style="margin-bottom: 16px;"></mat-divider>
     <div class="pxb-auth-action-button-container">

--- a/login-workflow/src/pages/create-account-invite/create-account-invite.component.html
+++ b/login-workflow/src/pages/create-account-invite/create-account-invite.component.html
@@ -15,12 +15,12 @@
 
 <ng-container *ngIf="!hasEmptyStateError()">
     <pxb-create-account-eula-step
-        *ngIf="currentPageId === 0 && isValidRegistrationLink"
+        *ngIf="registrationUtils.getCurrentPage() === 0 && isValidRegistrationLink"
         [(userAcceptsEula)]="userAcceptsEula"
     ></pxb-create-account-eula-step>
 
     <pxb-create-account-create-password-step
-        *ngIf="currentPageId === 1"
+        *ngIf="registrationUtils.getCurrentPage() === 1"
         [(password)]="password"
         [(passwordMeetsRequirements)]="passwordMeetsRequirements"
         (advance)="canContinue() ? goNext() : ''"
@@ -28,40 +28,43 @@
 
     <!-- Page 1 -->
     <pxb-create-account-account-details-step
-        *ngIf="showAccountDetailPage(0)"
+        *ngIf="registrationUtils.showAccountDetailsPage(0)"
         [showDefaultAccountDetails]="true"
         [(firstName)]="firstName"
         [(lastName)]="lastName"
         (accountNameValid)="validAccountName = $event"
         (advance)="canContinue() ? goNext() : ''"
     >
-        <ng-content pxb-account-details-form select="[pxb-account-details-form-page-1]"></ng-content>
+        <ng-content pxb-account-details select="[pxb-account-details-page-0]"></ng-content>
     </pxb-create-account-account-details-step>
 
     <!-- Page 2 -->
-    <pxb-create-account-account-details-step *ngIf="showAccountDetailPage(1)">
-        <ng-content pxb-account-details-form select="[pxb-account-details-form-page-2]"></ng-content>
+    <pxb-create-account-account-details-step *ngIf="registrationUtils.showAccountDetailsPage(1)">
+        <ng-content pxb-account-details select="[pxb-account-details-page-1]"></ng-content>
     </pxb-create-account-account-details-step>
 
     <!-- Page 3 -->
-    <pxb-create-account-account-details-step *ngIf="showAccountDetailPage(2)">
-        <ng-content pxb-account-details-form select="[pxb-account-details-form-page-3]"></ng-content>
+    <pxb-create-account-account-details-step *ngIf="registrationUtils.showAccountDetailsPage(2)">
+        <ng-content pxb-account-details select="[pxb-account-details-page-2]"></ng-content>
     </pxb-create-account-account-details-step>
 
     <!-- Page 4 -->
-    <pxb-create-account-account-details-step *ngIf="showAccountDetailPage(3)">
-        <ng-content pxb-account-details-form select="[pxb-account-details-form-page-4]"></ng-content>
+    <pxb-create-account-account-details-step *ngIf="registrationUtils.showAccountDetailsPage(3)">
+        <ng-content pxb-account-details select="[pxb-account-details-page-3]"></ng-content>
     </pxb-create-account-account-details-step>
 
     <pxb-create-account-account-created-step
-        *ngIf="showAccountCreated()"
+        *ngIf="registrationUtils.showAccountCreatedPage()"
         [userName]="getUserName()"
     ></pxb-create-account-account-created-step>
 
     <mat-divider class="pxb-auth-divider" style="margin-bottom: 16px;"></mat-divider>
     <div class="pxb-auth-action-button-container">
-        <ng-container *ngIf="showStepper()">
-            <pxb-mobile-stepper [steps]="getNumberOfSteps()" [activeStep]="currentPageId">
+        <ng-container *ngIf="!registrationUtils.showAccountCreatedPage()">
+            <pxb-mobile-stepper
+                [steps]="registrationUtils.getNumberOfSteps()"
+                [activeStep]="registrationUtils.getCurrentPage()"
+            >
                 <button pxb-back-button mat-stroked-button color="primary" style="width: 100px;" (click)="goBack()">
                     Back
                 </button>
@@ -77,7 +80,13 @@
                 </button>
             </pxb-mobile-stepper>
         </ng-container>
-        <button *ngIf="!showStepper()" mat-flat-button color="primary" (click)="navigateToLogin()" style="width: 100%">
+        <button
+            *ngIf="registrationUtils.showAccountCreatedPage()"
+            mat-flat-button
+            color="primary"
+            (click)="navigateToLogin()"
+            style="width: 100%"
+        >
             Continue
         </button>
     </div>

--- a/login-workflow/src/pages/create-account-invite/create-account-invite.component.html
+++ b/login-workflow/src/pages/create-account-invite/create-account-invite.component.html
@@ -28,29 +28,25 @@
 
     <!-- Page 1 -->
     <pxb-create-account-account-details-step
-        *ngIf="registrationUtils.showAccountDetailsPage(0)"
+        *ngIf="registrationUtils.isFirstAccountDetailsPage()"
         [showDefaultAccountDetails]="true"
         [(firstName)]="firstName"
         [(lastName)]="lastName"
         (accountNameValid)="validAccountName = $event"
         (advance)="canContinue() ? goNext() : ''"
     >
-        <ng-content pxb-account-details select="[pxb-account-details-page-0]"></ng-content>
+        <template
+            pxb-account-details
+            [ngTemplateOutlet]="registrationUtils.getCustomAccountDetailsTemplate()"
+        ></template>
     </pxb-create-account-account-details-step>
 
-    <!-- Page 2 -->
-    <pxb-create-account-account-details-step *ngIf="registrationUtils.showAccountDetailsPage(1)">
-        <ng-content pxb-account-details select="[pxb-account-details-page-1]"></ng-content>
-    </pxb-create-account-account-details-step>
-
-    <!-- Page 3 -->
-    <pxb-create-account-account-details-step *ngIf="registrationUtils.showAccountDetailsPage(2)">
-        <ng-content pxb-account-details select="[pxb-account-details-page-2]"></ng-content>
-    </pxb-create-account-account-details-step>
-
-    <!-- Page 4 -->
-    <pxb-create-account-account-details-step *ngIf="registrationUtils.showAccountDetailsPage(3)">
-        <ng-content pxb-account-details select="[pxb-account-details-page-3]"></ng-content>
+    <!-- Custom Account Details Pages -->
+    <pxb-create-account-account-details-step *ngIf="registrationUtils.isCustomAccountsDetailsPage()">
+        <template
+            pxb-account-details
+            [ngTemplateOutlet]="registrationUtils.getCustomAccountDetailsTemplate()"
+        ></template>
     </pxb-create-account-account-details-step>
 
     <pxb-create-account-account-created-step

--- a/login-workflow/src/pages/create-account-invite/create-account-invite.component.ts
+++ b/login-workflow/src/pages/create-account-invite/create-account-invite.component.ts
@@ -58,14 +58,6 @@ export class PxbCreateAccountInviteComponent implements OnInit, OnDestroy {
         this.stateListener.unsubscribe();
     }
 
-    clearAccountDetailsInfo(): void {
-        for (const detail of this.accountDetails) {
-            for (const formControl of detail.formControls) {
-                formControl.reset();
-            }
-        }
-    }
-
     validateRegistrationLink(): void {
         this._pxbSecurityService.setLoadingMessage('Validating registration link...');
         this._pxbSecurityService.setLoading(true);
@@ -135,7 +127,7 @@ export class PxbCreateAccountInviteComponent implements OnInit, OnDestroy {
     }
 
     navigateToLogin(): void {
-        this.clearAccountDetailsInfo();
+        this.registrationUtils.clearAccountDetails();
         void this._router.navigate([`${AUTH_ROUTES.AUTH_WORKFLOW}/${AUTH_ROUTES.LOGIN}`]);
     }
 

--- a/login-workflow/src/pages/create-account-invite/create-account-invite.component.ts
+++ b/login-workflow/src/pages/create-account-invite/create-account-invite.component.ts
@@ -8,7 +8,7 @@ import { PxbAuthSecurityService, SecurityContext } from '../../services/state/au
 import { PxbCreateAccountInviteErrorDialogService } from '../../services/dialog/create-account-invite-error-dialog.service';
 import { ErrorDialogData } from '../../services/dialog/error-dialog.service';
 import { Subscription } from 'rxjs';
-import {AccountDetails} from "../..";
+import { AccountDetails } from '../..';
 
 const ACCOUNT_DETAILS_STARTING_PAGE = 2;
 
@@ -61,7 +61,7 @@ export class PxbCreateAccountInviteComponent implements OnInit, OnDestroy {
 
     clearAccountDetailsInfo(): void {
         for (const detail of this.accountDetails) {
-            for (const formControl of detail.forms) {
+            for (const formControl of detail.formControls) {
                 formControl.reset();
             }
         }
@@ -85,12 +85,14 @@ export class PxbCreateAccountInviteComponent implements OnInit, OnDestroy {
 
     registerAccount(): void {
         this._pxbSecurityService.setLoading(true);
-        const formControls = [];
+        const customAccountDetails = [];
         for (const detail of this.accountDetails) {
-            formControls.concat(detail.forms);
+            for (const control of detail.formControls) {
+                customAccountDetails.push(control.value);
+            }
         }
         this._pxbRegisterService
-            .completeRegistration(this.firstName, this.lastName, formControls, this.password)
+            .completeRegistration(this.firstName, this.lastName, customAccountDetails, this.password)
             .then(() => {
                 this._pxbSecurityService.setLoading(false);
                 this.currentPageId++;
@@ -153,20 +155,22 @@ export class PxbCreateAccountInviteComponent implements OnInit, OnDestroy {
     isAccountDetailsPage(): boolean {
         return (
             this.currentPageId >= ACCOUNT_DETAILS_STARTING_PAGE &&
-            this.currentPageId < ACCOUNT_DETAILS_STARTING_PAGE + this.getNumberOfAccountsDetailsPages());
+            this.currentPageId < ACCOUNT_DETAILS_STARTING_PAGE + this.getNumberOfAccountsDetailsPages()
+        );
     }
 
     isLastAccountDetailsPage(): boolean {
-        return this.currentPageId === (ACCOUNT_DETAILS_STARTING_PAGE + this.getNumberOfAccountsDetailsPages());
+        return this.currentPageId === ACCOUNT_DETAILS_STARTING_PAGE + this.getNumberOfAccountsDetailsPages() - 1;
     }
 
     isAccountDetailsPopulated(index: number): boolean {
-        return this.accountDetails && this.accountDetails[index] && this.accountDetails[index].forms.length > 0;
+        return this.accountDetails && this.accountDetails[index] && this.accountDetails[index].formControls.length > 0;
     }
 
     showAccountDetailPage(page: number): boolean {
-        return page < this.getNumberOfAccountsDetailsPages() &&
-            this.currentPageId === ACCOUNT_DETAILS_STARTING_PAGE + page;
+        return (
+            page < this.getNumberOfAccountsDetailsPages() && this.currentPageId === ACCOUNT_DETAILS_STARTING_PAGE + page
+        );
     }
 
     showAccountCreated(): boolean {

--- a/login-workflow/src/pages/create-account-invite/create-account-invite.component.ts
+++ b/login-workflow/src/pages/create-account-invite/create-account-invite.component.ts
@@ -93,6 +93,12 @@ export class PxbCreateAccountInviteComponent implements OnInit, OnDestroy {
             });
     }
 
+    attemptContinue(): void {
+        if (this.canContinue()) {
+            this.goNext();
+        }
+    }
+
     canContinue(): boolean {
         if (this.registrationUtils.isAccountDetailsPage()) {
             return this.registrationUtils.isFirstAccountDetailsPage()

--- a/login-workflow/src/pages/create-account/create-account.component.html
+++ b/login-workflow/src/pages/create-account/create-account.component.html
@@ -25,17 +25,26 @@
 ></pxb-create-account-create-password-step>
 
 <pxb-create-account-account-details-step
-    *ngIf="currentPageId === 4 && !skipAccountDetails()"
-    [useDefaultAccountDetails]="useDefaultAccountDetails"
-    (accountDetailsChange)="accountDetails = $event"
-    (validAccountDetailsChange)="hasValidAccountDetails = $event"
+    *ngIf="currentPageId === 4"
+    [showDefaultAccountDetails]="true"
+    (firstName)="firstName = $event"
+    (lastName)="lastName = $event"
+    (accountNameValid)="validAccountName = $event"
     (advance)="canContinue() ? goNext() : ''"
 >
-    <ng-content pxb-account-details-form select="[pxb-account-details-form]"></ng-content>
+    <ng-content pxb-account-details-form select="[pxb-account-details-form-page-1]"></ng-content>
+</pxb-create-account-account-details-step>
+
+<pxb-create-account-account-details-step
+    *ngIf="currentPageId === 5 && hasExtendedAccountDetails()"
+    [showDefaultAccountDetails]="false"
+    (advance)="canContinue() ? goNext() : ''"
+>
+    <ng-content pxb-account-details-form select="[pxb-account-details-form-page-2]"></ng-content>
 </pxb-create-account-account-details-step>
 
 <pxb-create-account-account-created-step
-    *ngIf="currentPageId === 5 || (currentPageId === 4 && skipAccountDetails())"
+    *ngIf="(currentPageId === 5 && !hasExtendedAccountDetails()) || currentPageId === 6"
     [userName]="getUserName()"
     [email]="email"
 >

--- a/login-workflow/src/pages/create-account/create-account.component.html
+++ b/login-workflow/src/pages/create-account/create-account.component.html
@@ -1,66 +1,69 @@
 <pxb-create-account-provide-email-step
-    *ngIf="currentPageId === 0"
+    *ngIf="registrationUtils.getCurrentPage() === 0"
     [(email)]="email"
     [(isValidEmail)]="isValidEmail"
     (advance)="canContinue() ? goNext() : ''"
 ></pxb-create-account-provide-email-step>
 
 <pxb-create-account-eula-step
-    *ngIf="currentPageId === 1"
+    *ngIf="registrationUtils.getCurrentPage() === 1"
     [(userAcceptsEula)]="userAcceptsEula"
 ></pxb-create-account-eula-step>
 
 <pxb-create-account-verify-email-step
-    *ngIf="currentPageId === 2"
+    *ngIf="registrationUtils.getCurrentPage() === 2"
     [email]="email"
     [(verificationCode)]="verificationCode"
     (advance)="canContinue() ? goNext() : ''"
 ></pxb-create-account-verify-email-step>
 
 <pxb-create-account-create-password-step
-    *ngIf="currentPageId === 3"
+    *ngIf="registrationUtils.getCurrentPage() === 3"
     [(password)]="password"
     [(passwordMeetsRequirements)]="passwordMeetsRequirements"
     (advance)="canContinue() ? goNext() : ''"
 ></pxb-create-account-create-password-step>
 
-<!-- Page 1 -->
+<!-- First Account Details Page -->
 <pxb-create-account-account-details-step
-    *ngIf="showAccountDetailPage(0)"
+    *ngIf="registrationUtils.showAccountDetailsPage(0)"
     [showDefaultAccountDetails]="true"
     [(firstName)]="firstName"
     [(lastName)]="lastName"
     (accountNameValid)="validAccountName = $event"
     (advance)="canContinue() ? goNext() : ''"
 >
-    <ng-content pxb-account-details-form select="[pxb-account-details-form-page-1]"></ng-content>
+    <ng-content pxb-account-details select="[pxb-account-details-page-0]"></ng-content>
 </pxb-create-account-account-details-step>
 
-<!-- Page 2 -->
-<pxb-create-account-account-details-step *ngIf="showAccountDetailPage(1)">
-    <ng-content pxb-account-details-form select="[pxb-account-details-form-page-2]"></ng-content>
+<!-- Second Account Details Page -->
+<pxb-create-account-account-details-step *ngIf="registrationUtils.showAccountDetailsPage(1)">
+    <ng-content pxb-account-details select="[pxb-account-details-page-1]"></ng-content>
 </pxb-create-account-account-details-step>
 
-<!-- Page 3 -->
-<pxb-create-account-account-details-step *ngIf="showAccountDetailPage(2)">
-    <ng-content pxb-account-details-form select="[pxb-account-details-form-page-3]"></ng-content>
+<!-- Third Account Details Page -->
+<pxb-create-account-account-details-step *ngIf="registrationUtils.showAccountDetailsPage(2)">
+    <ng-content pxb-account-details select="[pxb-account-details-page-2]"></ng-content>
 </pxb-create-account-account-details-step>
 
-<!-- Page 4 -->
-<pxb-create-account-account-details-step *ngIf="showAccountDetailPage(3)">
-    <ng-content pxb-account-details-form select="[pxb-account-details-form-page-4]"></ng-content>
+<!-- Fourth Account Details Page -->
+<pxb-create-account-account-details-step *ngIf="registrationUtils.showAccountDetailsPage(3)">
+    <ng-content pxb-account-details select="[pxb-account-details-page-3]"></ng-content>
 </pxb-create-account-account-details-step>
 
 <pxb-create-account-account-created-step
-    *ngIf="showAccountCreated()"
+    *ngIf="registrationUtils.showAccountCreatedPage()"
     [userName]="getUserName()"
     [email]="email"
 ></pxb-create-account-account-created-step>
 
 <mat-divider class="pxb-auth-divider" style="margin-bottom: 16px;"></mat-divider>
 <div class="pxb-auth-action-button-container">
-    <ng-container *ngIf="showStepper()">
-        <pxb-mobile-stepper [steps]="getNumberOfSteps()" [activeStep]="currentPageId">
+    <ng-container *ngIf="!registrationUtils.showAccountCreatedPage()">
+        <pxb-mobile-stepper
+            [steps]="registrationUtils.getNumberOfSteps()"
+            [activeStep]="registrationUtils.getCurrentPage()"
+        >
             <button pxb-back-button mat-stroked-button color="primary" style="width: 100px;" (click)="goBack()">
                 Back
             </button>
@@ -76,7 +79,13 @@
             </button>
         </pxb-mobile-stepper>
     </ng-container>
-    <button *ngIf="!showStepper()" mat-flat-button color="primary" (click)="navigateToLogin()" style="width: 100%">
+    <button
+        *ngIf="registrationUtils.showAccountCreatedPage()"
+        mat-flat-button
+        color="primary"
+        (click)="navigateToLogin()"
+        style="width: 100%"
+    >
         Continue
     </button>
 </div>

--- a/login-workflow/src/pages/create-account/create-account.component.html
+++ b/login-workflow/src/pages/create-account/create-account.component.html
@@ -24,31 +24,38 @@
     (advance)="canContinue() ? goNext() : ''"
 ></pxb-create-account-create-password-step>
 
+<!-- Page 1 -->
 <pxb-create-account-account-details-step
-    *ngIf="currentPageId === 4"
+    *ngIf="showAccountDetailPage(0)"
     [showDefaultAccountDetails]="true"
-    (firstName)="firstName = $event"
-    (lastName)="lastName = $event"
+    [(firstName)]="firstName"
+    [(lastName)]="lastName"
     (accountNameValid)="validAccountName = $event"
     (advance)="canContinue() ? goNext() : ''"
 >
     <ng-content pxb-account-details-form select="[pxb-account-details-form-page-1]"></ng-content>
 </pxb-create-account-account-details-step>
 
-<pxb-create-account-account-details-step
-    *ngIf="currentPageId === 5 && hasExtendedAccountDetails()"
-    [showDefaultAccountDetails]="false"
-    (advance)="canContinue() ? goNext() : ''"
->
+<!-- Page 2 -->
+<pxb-create-account-account-details-step *ngIf="showAccountDetailPage(1)">
     <ng-content pxb-account-details-form select="[pxb-account-details-form-page-2]"></ng-content>
 </pxb-create-account-account-details-step>
 
+<!-- Page 3 -->
+<pxb-create-account-account-details-step *ngIf="showAccountDetailPage(2)">
+    <ng-content pxb-account-details-form select="[pxb-account-details-form-page-3]"></ng-content>
+</pxb-create-account-account-details-step>
+
+<!-- Page 4 -->
+<pxb-create-account-account-details-step *ngIf="showAccountDetailPage(3)">
+    <ng-content pxb-account-details-form select="[pxb-account-details-form-page-4]"></ng-content>
+</pxb-create-account-account-details-step>
+
 <pxb-create-account-account-created-step
-    *ngIf="(currentPageId === 5 && !hasExtendedAccountDetails()) || currentPageId === 6"
+    *ngIf="showAccountCreated()"
     [userName]="getUserName()"
     [email]="email"
->
-</pxb-create-account-account-created-step>
+></pxb-create-account-account-created-step>
 
 <mat-divider class="pxb-auth-divider" style="margin-bottom: 16px;"></mat-divider>
 <div class="pxb-auth-action-button-container">

--- a/login-workflow/src/pages/create-account/create-account.component.html
+++ b/login-workflow/src/pages/create-account/create-account.component.html
@@ -2,7 +2,7 @@
     *ngIf="registrationUtils.getCurrentPage() === 0"
     [(email)]="email"
     [(isValidEmail)]="isValidEmail"
-    (advance)="canContinue() ? goNext() : ''"
+    (advance)="attemptContinue()"
 ></pxb-create-account-provide-email-step>
 
 <pxb-create-account-eula-step
@@ -14,14 +14,14 @@
     *ngIf="registrationUtils.getCurrentPage() === 2"
     [email]="email"
     [(verificationCode)]="verificationCode"
-    (advance)="canContinue() ? goNext() : ''"
+    (advance)="attemptContinue()"
 ></pxb-create-account-verify-email-step>
 
 <pxb-create-account-create-password-step
     *ngIf="registrationUtils.getCurrentPage() === 3"
     [(password)]="password"
     [(passwordMeetsRequirements)]="passwordMeetsRequirements"
-    (advance)="canContinue() ? goNext() : ''"
+    (advance)="attemptContinue()"
 ></pxb-create-account-create-password-step>
 
 <!-- First Account Details Page -->
@@ -31,7 +31,7 @@
     [(firstName)]="firstName"
     [(lastName)]="lastName"
     (accountNameValid)="validAccountName = $event"
-    (advance)="canContinue() ? goNext() : ''"
+    (advance)="attemptContinue()"
 >
     <template pxb-account-details [ngTemplateOutlet]="registrationUtils.getCustomAccountDetailsTemplate()"></template>
 </pxb-create-account-account-details-step>

--- a/login-workflow/src/pages/create-account/create-account.component.html
+++ b/login-workflow/src/pages/create-account/create-account.component.html
@@ -26,29 +26,19 @@
 
 <!-- First Account Details Page -->
 <pxb-create-account-account-details-step
-    *ngIf="registrationUtils.showAccountDetailsPage(0)"
+    *ngIf="registrationUtils.isFirstAccountDetailsPage()"
     [showDefaultAccountDetails]="true"
     [(firstName)]="firstName"
     [(lastName)]="lastName"
     (accountNameValid)="validAccountName = $event"
     (advance)="canContinue() ? goNext() : ''"
 >
-    <ng-content pxb-account-details select="[pxb-account-details-page-0]"></ng-content>
+    <template pxb-account-details [ngTemplateOutlet]="registrationUtils.getCustomAccountDetailsTemplate()"></template>
 </pxb-create-account-account-details-step>
 
-<!-- Second Account Details Page -->
-<pxb-create-account-account-details-step *ngIf="registrationUtils.showAccountDetailsPage(1)">
-    <ng-content pxb-account-details select="[pxb-account-details-page-1]"></ng-content>
-</pxb-create-account-account-details-step>
-
-<!-- Third Account Details Page -->
-<pxb-create-account-account-details-step *ngIf="registrationUtils.showAccountDetailsPage(2)">
-    <ng-content pxb-account-details select="[pxb-account-details-page-2]"></ng-content>
-</pxb-create-account-account-details-step>
-
-<!-- Fourth Account Details Page -->
-<pxb-create-account-account-details-step *ngIf="registrationUtils.showAccountDetailsPage(3)">
-    <ng-content pxb-account-details select="[pxb-account-details-page-3]"></ng-content>
+<!-- Custom Account Details Pages -->
+<pxb-create-account-account-details-step *ngIf="registrationUtils.isCustomAccountsDetailsPage()">
+    <template pxb-account-details [ngTemplateOutlet]="registrationUtils.getCustomAccountDetailsTemplate()"></template>
 </pxb-create-account-account-details-step>
 
 <pxb-create-account-account-created-step

--- a/login-workflow/src/pages/create-account/create-account.component.ts
+++ b/login-workflow/src/pages/create-account/create-account.component.ts
@@ -109,6 +109,12 @@ export class PxbCreateAccountComponent implements OnDestroy {
             });
     }
 
+    attemptContinue(): void {
+        if (this.canContinue()) {
+            this.goNext();
+        }
+    }
+
     canContinue(): boolean {
         if (this.registrationUtils.isAccountDetailsPage()) {
             return this.registrationUtils.isFirstAccountDetailsPage()

--- a/login-workflow/src/pages/create-account/create-account.component.ts
+++ b/login-workflow/src/pages/create-account/create-account.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnDestroy } from '@angular/core';
+import { Component, Input, OnDestroy, TemplateRef } from '@angular/core';
 import { Router } from '@angular/router';
 
 import { AUTH_ROUTES } from '../../auth/auth.routes';
@@ -10,10 +10,12 @@ import { ErrorDialogData } from '../../services/dialog/error-dialog.service';
 import { FormControl } from '@angular/forms';
 import { Subscription } from 'rxjs';
 import { CreateAccountService } from './create-account.service';
+import { MatFormField } from '@angular/material/form-field';
 
 const ACCOUNT_DETAILS_STARTING_PAGE = 4;
 
 export type AccountDetails = {
+    form: TemplateRef<MatFormField>;
     formControls: FormControl[];
     isValid: () => boolean;
 };

--- a/login-workflow/src/pages/create-account/create-account.component.ts
+++ b/login-workflow/src/pages/create-account/create-account.component.ts
@@ -13,7 +13,7 @@ import { Subscription } from 'rxjs';
 const ACCOUNT_DETAILS_STARTING_PAGE = 4;
 
 export type AccountDetails = {
-    forms: FormControl[];
+    formControls: FormControl[];
     isValid: () => boolean;
 };
 
@@ -69,7 +69,7 @@ export class PxbCreateAccountComponent implements OnDestroy {
 
     clearAccountDetailsInfo(): void {
         for (const detail of this.accountDetails) {
-            for (const formControl of detail.forms) {
+            for (const formControl of detail.formControls) {
                 formControl.reset();
             }
         }
@@ -91,15 +91,17 @@ export class PxbCreateAccountComponent implements OnDestroy {
 
     registerAccount(): void {
         this._pxbSecurityService.setLoading(true);
-        const formControls = [];
+        const customAccountDetails = [];
         for (const detail of this.accountDetails) {
-            formControls.concat(detail.forms);
+            for (const control of detail.formControls) {
+                customAccountDetails.push(control.value);
+            }
         }
         this._pxbRegisterService
             .completeRegistration(
                 this.firstName,
                 this.lastName,
-                formControls,
+                customAccountDetails,
                 this.password,
                 this.verificationCode,
                 this.email
@@ -151,6 +153,7 @@ export class PxbCreateAccountComponent implements OnDestroy {
     }
 
     navigateToLogin(): void {
+        this.clearAccountDetailsInfo();
         void this._router.navigate([`${AUTH_ROUTES.AUTH_WORKFLOW}/${AUTH_ROUTES.LOGIN}`]);
     }
 
@@ -169,20 +172,22 @@ export class PxbCreateAccountComponent implements OnDestroy {
     isAccountDetailsPage(): boolean {
         return (
             this.currentPageId >= ACCOUNT_DETAILS_STARTING_PAGE &&
-            this.currentPageId < ACCOUNT_DETAILS_STARTING_PAGE + this.getNumberOfAccountsDetailsPages());
+            this.currentPageId < ACCOUNT_DETAILS_STARTING_PAGE + this.getNumberOfAccountsDetailsPages()
+        );
     }
 
     isLastAccountDetailsPage(): boolean {
-        return this.currentPageId === (ACCOUNT_DETAILS_STARTING_PAGE + this.getNumberOfAccountsDetailsPages());
+        return this.currentPageId === ACCOUNT_DETAILS_STARTING_PAGE + this.getNumberOfAccountsDetailsPages() - 1;
     }
 
     isAccountDetailsPopulated(index: number): boolean {
-        return this.accountDetails && this.accountDetails[index] && this.accountDetails[index].forms.length > 0;
+        return this.accountDetails && this.accountDetails[index] && this.accountDetails[index].formControls.length > 0;
     }
 
     showAccountDetailPage(page: number): boolean {
-        return page < this.getNumberOfAccountsDetailsPages() &&
-            this.currentPageId === ACCOUNT_DETAILS_STARTING_PAGE + page;
+        return (
+            page < this.getNumberOfAccountsDetailsPages() && this.currentPageId === ACCOUNT_DETAILS_STARTING_PAGE + page
+        );
     }
 
     showAccountCreated(): boolean {

--- a/login-workflow/src/pages/create-account/create-account.component.ts
+++ b/login-workflow/src/pages/create-account/create-account.component.ts
@@ -1,5 +1,8 @@
 import { Component, Input, OnDestroy, TemplateRef } from '@angular/core';
 import { Router } from '@angular/router';
+import { MatFormField } from '@angular/material/form-field';
+import { FormControl } from '@angular/forms';
+import { Subscription } from 'rxjs';
 
 import { AUTH_ROUTES } from '../../auth/auth.routes';
 import { PxbAuthConfig } from '../../services/config/auth-config';
@@ -7,16 +10,13 @@ import { PxbRegisterUIService } from '../../services/api/register-ui.service';
 import { PxbAuthSecurityService, SecurityContext } from '../../services/state/auth-security.service';
 import { PxbCreateAccountErrorDialogService } from '../../services/dialog/create-account-error-dialog.service';
 import { ErrorDialogData } from '../../services/dialog/error-dialog.service';
-import { FormControl } from '@angular/forms';
-import { Subscription } from 'rxjs';
 import { CreateAccountService } from './create-account.service';
-import { MatFormField } from '@angular/material/form-field';
 
 const ACCOUNT_DETAILS_STARTING_PAGE = 4;
 
 export type AccountDetails = {
     form: TemplateRef<MatFormField>;
-    formControls: FormControl[];
+    formControls: Map<string, FormControl>;
     isValid: () => boolean;
 };
 

--- a/login-workflow/src/pages/create-account/create-account.service.ts
+++ b/login-workflow/src/pages/create-account/create-account.service.ts
@@ -1,0 +1,93 @@
+import { AccountDetails } from './create-account.component';
+
+export class CreateAccountService {
+    /* Account Registration Pages start with 0 index. */
+    currentPage = 0;
+
+    constructor(public detailsStartPage: number, public accountDetails: AccountDetails[]) {}
+
+    /* Decrements currentPage index by 1. */
+    prevStep(): void {
+        this.currentPage--;
+    }
+
+    /* Increments currentPage index by 1. */
+    nextStep(): void {
+        this.currentPage++;
+    }
+
+    /* Returns current page number. */
+    getCurrentPage(): number {
+        return this.currentPage;
+    }
+
+    /* Returns true if the current page is an Accounts Details entry page. */
+    isAccountDetailsPage(): boolean {
+        return (
+            this.currentPage >= this.detailsStartPage &&
+            this.currentPage < this.detailsStartPage + this.getNumberOfAccountDetailsPages()
+        );
+    }
+
+    /* Returns true if on-screen custom account detail forms contain valid entries. */
+    hasValidAccountDetails(): boolean {
+        const detailsIndex = this.currentPage - this.detailsStartPage; /* index of custom accountDetails to use. */
+        const hasCustomForms = this.hasDetailsAtIndex(detailsIndex);
+        return !hasCustomForms || this.accountDetails[detailsIndex].isValid();
+    }
+
+    /* Returns true if current page is the first account details page. */
+    isFirstAccountDetailsPage(): boolean {
+        return this.currentPage === this.detailsStartPage;
+    }
+
+    /* Returns true if the current page is the last account details page. */
+    isLastAccountDetailsPage(): boolean {
+        return this.currentPage === this.detailsStartPage + this.getNumberOfAccountDetailsPages() - 1;
+    }
+
+    /* Searches for custom AccountDetails and returns true if it exists. */
+    hasDetailsAtIndex(index: number): boolean {
+        return this.accountDetails && this.accountDetails[index] && this.accountDetails[index].formControls.length > 0;
+    }
+
+    /* Returns true if the potentialPage should be shown as the currentPage. */
+    showAccountDetailsPage(page: number): boolean {
+        return page < this.getNumberOfAccountDetailsPages() && this.currentPage === this.detailsStartPage + page;
+    }
+
+    /* Returns how many pages of account details a user will have to fill out. */
+    getNumberOfAccountDetailsPages(): number {
+        return this.accountDetails.length === 0 ? 1 : this.accountDetails.length;
+    }
+
+    /* Returns true when the user has finished the account-details section of self-registration. */
+    showAccountCreatedPage(): boolean {
+        return this.currentPage === this.detailsStartPage + this.getNumberOfAccountDetailsPages();
+    }
+
+    /* Returns the number of steps to show in the mobile stepper based off of how many account details pages there are. */
+    getNumberOfSteps(): number {
+        return this.detailsStartPage + this.getNumberOfAccountDetailsPages();
+    }
+
+    /* Called upon completing the self-registration process, empties all forms.  */
+    clearAccountDetails(): void {
+        for (const detail of this.accountDetails) {
+            for (const formControl of detail.formControls) {
+                formControl.reset();
+            }
+        }
+    }
+
+    /* Returns string[] of custom account detail values. */
+    getAccountDetailsCustomValues(): string[] {
+        const customAccountDetails = [];
+        for (const detail of this.accountDetails) {
+            for (const control of detail.formControls) {
+                customAccountDetails.push(control.value);
+            }
+        }
+        return customAccountDetails;
+    }
+}

--- a/login-workflow/src/pages/create-account/create-account.service.ts
+++ b/login-workflow/src/pages/create-account/create-account.service.ts
@@ -1,7 +1,7 @@
 import { AccountDetails } from './create-account.component';
 import { TemplateRef } from '@angular/core';
 import { MatFormField } from '@angular/material/form-field';
-import {FormControl} from "@angular/forms";
+import { FormControl } from '@angular/forms';
 
 export class CreateAccountService {
     /* Account Registration Pages start with 0 index. */
@@ -104,7 +104,7 @@ export class CreateAccountService {
             if (detail && detail.formControls) {
                 detail.formControls.forEach((formControl, key) => {
                     customAccountDetails.set(key, formControl);
-                })
+                });
             }
         }
         return customAccountDetails;

--- a/login-workflow/src/pages/create-account/create-account.service.ts
+++ b/login-workflow/src/pages/create-account/create-account.service.ts
@@ -1,6 +1,7 @@
 import { AccountDetails } from './create-account.component';
 import { TemplateRef } from '@angular/core';
 import { MatFormField } from '@angular/material/form-field';
+import {FormControl} from "@angular/forms";
 
 export class CreateAccountService {
     /* Account Registration Pages start with 0 index. */
@@ -58,7 +59,7 @@ export class CreateAccountService {
             this.accountDetails &&
             this.accountDetails[index] &&
             this.accountDetails[index].formControls &&
-            this.accountDetails[index].formControls.length > 0
+            this.accountDetails[index].formControls.size > 0
         );
     }
 
@@ -88,18 +89,22 @@ export class CreateAccountService {
     /* Called upon completing the self-registration process, empties all forms.  */
     clearAccountDetails(): void {
         for (const detail of this.accountDetails) {
-            for (const formControl of detail?.formControls || []) {
-                formControl.reset();
+            if (detail && detail.formControls) {
+                for (const formControls of detail.formControls.values()) {
+                    formControls.reset();
+                }
             }
         }
     }
 
     /* Returns string[] of custom account detail values. */
-    getAccountDetailsCustomValues(): string[] {
-        const customAccountDetails = [];
+    getAccountDetailsCustomValues(): Map<string, FormControl> {
+        const customAccountDetails: Map<string, FormControl> = new Map();
         for (const detail of this.accountDetails) {
-            for (const control of detail?.formControls || []) {
-                customAccountDetails.push(control.value);
+            if (detail && detail.formControls) {
+                detail.formControls.forEach((formControl, key) => {
+                    customAccountDetails.set(key, formControl);
+                })
             }
         }
         return customAccountDetails;

--- a/login-workflow/src/pages/create-account/steps/account-details/account-details.component.scss
+++ b/login-workflow/src/pages/create-account/steps/account-details/account-details.component.scss
@@ -1,0 +1,14 @@
+.pxb-account-details-body {
+    display: flex;
+    flex: 1 1 0px;
+    overflow: auto;
+    ::ng-deep {
+        form {
+            width: 100%;
+        }
+        mat-form-field {
+            width: 100%;
+            margin-bottom: 8px;
+        }
+    }
+}

--- a/login-workflow/src/pages/create-account/steps/account-details/account-details.component.ts
+++ b/login-workflow/src/pages/create-account/steps/account-details/account-details.component.ts
@@ -47,7 +47,7 @@ import { PxbFormsService } from '../../../../services/forms/forms.service';
                             </mat-error>
                         </mat-form-field>
                     </ng-container>
-                    <ng-content select="[pxb-account-details-form]"></ng-content>
+                    <ng-content select="[pxb-account-details]"></ng-content>
                 </form>
             </div>
         </div>

--- a/login-workflow/src/pages/create-account/steps/account-details/account-details.component.ts
+++ b/login-workflow/src/pages/create-account/steps/account-details/account-details.component.ts
@@ -4,6 +4,7 @@ import { PxbFormsService } from '../../../../services/forms/forms.service';
 
 @Component({
     selector: 'pxb-create-account-account-details-step',
+    styleUrls: ['account-details.component.scss'],
     template: `
         <div class="mat-title pxb-auth-title">Account Details</div>
         <div class="pxb-auth-full-height">
@@ -11,10 +12,10 @@ import { PxbFormsService } from '../../../../services/forms/forms.service';
                 Enter your details below to complete account creation.
             </p>
             <mat-divider class="pxb-auth-divider" style="margin-top: 16px; margin-bottom: 32px;"></mat-divider>
-            <div style="display: flex; flex: 1 1 0px; overflow: auto;">
-                <form [style.width.%]="100">
+            <div class="pxb-account-details-body">
+                <form>
                     <ng-container *ngIf="showDefaultAccountDetails">
-                        <mat-form-field appearance="fill" [style.width.%]="100" [style.marginBottom.px]="8">
+                        <mat-form-field appearance="fill">
                             <mat-label>First Name</mat-label>
                             <input
                                 #pxbFirst
@@ -30,7 +31,7 @@ import { PxbFormsService } from '../../../../services/forms/forms.service';
                                 First Name is <strong>required</strong>
                             </mat-error>
                         </mat-form-field>
-                        <mat-form-field appearance="fill" [style.width.%]="100" [style.marginBottom.px]="8">
+                        <mat-form-field appearance="fill">
                             <mat-label>Last Name</mat-label>
                             <input
                                 matInput

--- a/login-workflow/src/pages/create-account/steps/account-details/account-details.component.ts
+++ b/login-workflow/src/pages/create-account/steps/account-details/account-details.component.ts
@@ -12,7 +12,7 @@ import { PxbFormsService } from '../../../../services/forms/forms.service';
             </p>
             <mat-divider class="pxb-auth-divider" style="margin-top: 16px; margin-bottom: 32px;"></mat-divider>
             <div style="display: flex; flex: 1 1 0px; overflow: auto;">
-                <form>
+                <form [style.width.%]="100">
                     <ng-container *ngIf="showDefaultAccountDetails">
                         <mat-form-field appearance="fill" [style.width.%]="100" [style.marginBottom.px]="8">
                             <mat-label>First Name</mat-label>

--- a/login-workflow/src/pages/create-account/steps/account-details/account-details.component.ts
+++ b/login-workflow/src/pages/create-account/steps/account-details/account-details.component.ts
@@ -12,53 +12,42 @@ import { PxbFormsService } from '../../../../services/forms/forms.service';
             </p>
             <mat-divider class="pxb-auth-divider" style="margin-top: 16px; margin-bottom: 32px;"></mat-divider>
             <div style="display: flex; flex: 1 1 0px; overflow: auto;">
-                <ng-container *ngIf="!useDefaultAccountDetails">
+                <form>
+                    <ng-container *ngIf="showDefaultAccountDetails">
+                        <mat-form-field appearance="fill" [style.width.%]="100" [style.marginBottom.px]="8">
+                            <mat-label>First Name</mat-label>
+                            <input
+                                #pxbFirst
+                                id="pxb-first"
+                                name="first"
+                                matInput
+                                [formControl]="firstNameFormControl"
+                                required
+                                (ngModelChange)="emitIfValid(); firstName.emit(firstNameFormControl.value)"
+                                (keyup.enter)="pxbFormsService.advanceToNextField(lastNameInputElement)"
+                            />
+                            <mat-error *ngIf="firstNameFormControl.hasError('required')">
+                                First Name is <strong>required</strong>
+                            </mat-error>
+                        </mat-form-field>
+                        <mat-form-field appearance="fill" [style.width.%]="100" [style.marginBottom.px]="8">
+                            <mat-label>Last Name</mat-label>
+                            <input
+                                matInput
+                                #pxbLast
+                                id="pxb-last"
+                                name="last"
+                                [formControl]="lastNameFormControl"
+                                required
+                                (ngModelChange)="emitIfValid(); lastName.emit(lastNameFormControl.value)"
+                                (keyup.enter)="advance.emit(true)"
+                            />
+                            <mat-error *ngIf="lastNameFormControl.hasError('required')">
+                                Last Name is <strong>required</strong>
+                            </mat-error>
+                        </mat-form-field>
+                    </ng-container>
                     <ng-content select="[pxb-account-details-form]"></ng-content>
-                </ng-container>
-                <form *ngIf="useDefaultAccountDetails">
-                    <mat-form-field appearance="fill" [style.width.%]="100" [style.marginBottom.px]="8">
-                        <mat-label>First Name</mat-label>
-                        <input
-                            #pxbFirst
-                            id="pxb-first"
-                            name="first"
-                            matInput
-                            [formControl]="firstNameFormControl"
-                            required
-                            (ngModelChange)="emitIfValid()"
-                            (keyup.enter)="pxbFormsService.advanceToNextField(lastNameInputElement)"
-                        />
-                        <mat-error *ngIf="firstNameFormControl.hasError('required')">
-                            First Name is <strong>required</strong>
-                        </mat-error>
-                    </mat-form-field>
-                    <mat-form-field appearance="fill" [style.width.%]="100" [style.marginBottom.px]="8">
-                        <mat-label>Last Name</mat-label>
-                        <input
-                            matInput
-                            #pxbLast
-                            id="pxb-last"
-                            name="last"
-                            [formControl]="lastNameFormControl"
-                            required
-                            (ngModelChange)="emitIfValid()"
-                            (keyup.enter)="pxbFormsService.advanceToNextField(phoneInputElement)"
-                        />
-                        <mat-error *ngIf="lastNameFormControl.hasError('required')">
-                            Last Name is <strong>required</strong>
-                        </mat-error>
-                    </mat-form-field>
-                    <mat-form-field appearance="fill" [style.width.%]="100" [style.marginBottom.px]="8">
-                        <mat-label>Phone Number (optional)</mat-label>
-                        <input
-                            #pxbPhone
-                            id="pxb-phone"
-                            name="phone"
-                            matInput
-                            [formControl]="phoneNumberFormControl"
-                            (keyup.enter)="advance.emit(true)"
-                        />
-                    </mat-form-field>
                 </form>
             </div>
         </div>
@@ -66,36 +55,31 @@ import { PxbFormsService } from '../../../../services/forms/forms.service';
 })
 /* Default Account Details consists of a First/Last Name (required) and a phone number (optional). */
 export class PxbAccountDetailsComponent {
-    @Input() useDefaultAccountDetails = false;
+    @Input() showDefaultAccountDetails = false;
     @Output() accountDetailsChange = new EventEmitter<FormControl[]>();
-    @Output() validAccountDetailsChange = new EventEmitter<boolean>();
+    @Output() accountNameValid = new EventEmitter<boolean>();
     @Output() advance: EventEmitter<boolean> = new EventEmitter<boolean>();
+    @Output() firstName: EventEmitter<string> = new EventEmitter<string>();
+    @Output() lastName: EventEmitter<string> = new EventEmitter<string>();
 
     @ViewChild('pxbLast') lastNameInputElement: ElementRef;
-    @ViewChild('pxbPhone') phoneInputElement: ElementRef;
 
     firstNameFormControl: FormControl;
     lastNameFormControl: FormControl;
-    phoneNumberFormControl: FormControl;
 
     constructor(public pxbFormsService: PxbFormsService) {}
 
     ngOnInit(): void {
-        if (this.useDefaultAccountDetails) {
+        if (this.showDefaultAccountDetails) {
             this.firstNameFormControl = new FormControl('', Validators.required);
             this.lastNameFormControl = new FormControl('', Validators.required);
-            this.phoneNumberFormControl = new FormControl('');
-            this.accountDetailsChange.emit([
-                this.firstNameFormControl,
-                this.lastNameFormControl,
-                this.phoneNumberFormControl,
-            ]);
+            this.accountDetailsChange.emit([this.firstNameFormControl, this.lastNameFormControl]);
         }
     }
 
     /* If we are using the default account details, we need to provide the input validation required for the 'NEXT' button. */
     emitIfValid(): void {
-        this.validAccountDetailsChange.emit(
+        this.accountNameValid.emit(
             this.firstNameFormControl.value &&
                 this.firstNameFormControl.valid &&
                 this.lastNameFormControl.value &&

--- a/login-workflow/src/pages/create-account/steps/account-details/account-details.component.ts
+++ b/login-workflow/src/pages/create-account/steps/account-details/account-details.component.ts
@@ -23,7 +23,7 @@ import { PxbFormsService } from '../../../../services/forms/forms.service';
                                 matInput
                                 [formControl]="firstNameFormControl"
                                 required
-                                (ngModelChange)="emitIfValid(); firstName.emit(firstNameFormControl.value)"
+                                (ngModelChange)="emitIfValid(); firstNameChange.emit(firstNameFormControl.value)"
                                 (keyup.enter)="pxbFormsService.advanceToNextField(lastNameInputElement)"
                             />
                             <mat-error *ngIf="firstNameFormControl.hasError('required')">
@@ -39,7 +39,7 @@ import { PxbFormsService } from '../../../../services/forms/forms.service';
                                 name="last"
                                 [formControl]="lastNameFormControl"
                                 required
-                                (ngModelChange)="emitIfValid(); lastName.emit(lastNameFormControl.value)"
+                                (ngModelChange)="emitIfValid(); lastNameChange.emit(lastNameFormControl.value)"
                                 (keyup.enter)="advance.emit(true)"
                             />
                             <mat-error *ngIf="lastNameFormControl.hasError('required')">
@@ -56,11 +56,12 @@ import { PxbFormsService } from '../../../../services/forms/forms.service';
 /* Default Account Details consists of a First/Last Name (required) and a phone number (optional). */
 export class PxbAccountDetailsComponent {
     @Input() showDefaultAccountDetails = false;
-    @Output() accountDetailsChange = new EventEmitter<FormControl[]>();
+    @Input() firstName: string;
+    @Input() lastName: string;
+    @Output() firstNameChange: EventEmitter<string> = new EventEmitter<string>();
+    @Output() lastNameChange: EventEmitter<string> = new EventEmitter<string>();
     @Output() accountNameValid = new EventEmitter<boolean>();
     @Output() advance: EventEmitter<boolean> = new EventEmitter<boolean>();
-    @Output() firstName: EventEmitter<string> = new EventEmitter<string>();
-    @Output() lastName: EventEmitter<string> = new EventEmitter<string>();
 
     @ViewChild('pxbLast') lastNameInputElement: ElementRef;
 
@@ -71,9 +72,8 @@ export class PxbAccountDetailsComponent {
 
     ngOnInit(): void {
         if (this.showDefaultAccountDetails) {
-            this.firstNameFormControl = new FormControl('', Validators.required);
-            this.lastNameFormControl = new FormControl('', Validators.required);
-            this.accountDetailsChange.emit([this.firstNameFormControl, this.lastNameFormControl]);
+            this.firstNameFormControl = new FormControl(this.firstName, Validators.required);
+            this.lastNameFormControl = new FormControl(this.lastName, Validators.required);
         }
     }
 

--- a/login-workflow/src/services/api/register-ui.service.ts
+++ b/login-workflow/src/services/api/register-ui.service.ts
@@ -17,7 +17,7 @@ export type IPxbRegisterUIService = {
     completeRegistration(
         firstName: string,
         lastName: string,
-        customAccountDetails: string[],
+        customAccountDetails: Map<string, FormControl>,
         password: string,
         validationCode?: string,
         email?: string
@@ -51,7 +51,7 @@ export class PxbRegisterUIService implements IPxbRegisterUIService {
     completeRegistration(
         firstName: string,
         lastName: string,
-        customAccountDetails: string[],
+        customAccountDetails: Map<string, FormControl>,
         password: string,
         validationCode?: string,
         email?: string

--- a/login-workflow/src/services/api/register-ui.service.ts
+++ b/login-workflow/src/services/api/register-ui.service.ts
@@ -15,6 +15,8 @@ export type IPxbRegisterUIService = {
 
     // The user has been invited to register and has entered the necessary account and password information. The application should now complete the registration process given the user's data
     completeRegistration(
+        firstName: string,
+        lastName: string,
         formControls: FormControl[],
         password: string,
         validationCode?: string,
@@ -47,6 +49,8 @@ export class PxbRegisterUIService implements IPxbRegisterUIService {
     }
 
     completeRegistration(
+        firstName: string,
+        lastName: string,
         formControls: FormControl[],
         password: string,
         validationCode?: string,

--- a/login-workflow/src/services/api/register-ui.service.ts
+++ b/login-workflow/src/services/api/register-ui.service.ts
@@ -17,7 +17,7 @@ export type IPxbRegisterUIService = {
     completeRegistration(
         firstName: string,
         lastName: string,
-        formControls: FormControl[],
+        customAccountDetails: string[],
         password: string,
         validationCode?: string,
         email?: string
@@ -51,7 +51,7 @@ export class PxbRegisterUIService implements IPxbRegisterUIService {
     completeRegistration(
         firstName: string,
         lastName: string,
-        formControls: FormControl[],
+        customAccountDetails: string[],
         password: string,
         validationCode?: string,
         email?: string


### PR DESCRIPTION
<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Removes ability to skip account details.
- Makes First/Last name mandatory.
- Changes the way custom account details are passed into the self-registration screens.
- Adds CreateAccountService (internal) to help with rendering logic. 
- TODO: update docs

This is how to pass in custom account details.  We need these three things:

#### 1. Custom `<pxb-create-account>` component.

Each time a page customization happens through `ng-content` or `@Inputs`, this step is required.   
```
 <!-- Custom Create Account page -->
<ng-template #createAccountPage>
    <pxb-create-account [accountDetails]="accountDetails"></pxb-create-account>
</ng-template>
```


#### 2.  Custom forms accessible as a `TemplateRef`. 

This is what to render as your custom form.
```
<ng-template #customFormRef>
  <form>
      <mat-form-field appearance="fill" [style.width.%]="100" [style.marginBottom.px]="8">
          <mat-label>Custom Field</mat-label>
          <input matInput [formControl]="customFormControl" required />
          <mat-error *ngIf="customFormControl.hasError('required')">
              Emergency Contact is <strong>required</strong>
          </mat-error>
      </mat-form-field>
  </form>
</ng-template>
```

#### 3.  An `accountDetails[]` `@Input`
Each `accountDetails` object has 3 properties:

`form`: what to render
`formControls`: access what the user entered
`isValid()`: function we run to determine if user-input is valid.

Each `accountDetails` represents a new page in the self-registration process.  
```
import { AccountDetails } from '@pxblue/angular-auth-workflow';


// What to Render
@ViewChild('customFormRef') customFormRef: TemplateRef<MatFormField>;

// To capture user inputs
customFormControl: FormControl;

// An array of accountDetails where each object represents a new page. 
accountDetails: AccountDetails[]; 

ngAfterViewInit(): void {
  this.customFormControl= new FormControl('', Validators.required);
  this.accountDetails = [
      {   /* Page 1 */
          form: this.customFormRef,
          formControls: [this.customFormControl],
          isValid: () => this.customFormControl.value,
      }
  ];
}

```

This solution scales so that a user can have as many pages as they want.  

Users can even have blank custom pages as well.  This is useful if they do want want any custom forms on the first account details page (first/last name).  e.g.

```
/* Page 1 */
{
    form: undefined, formControls: undefined, isValid: () => true
},
/* Page 2 */
{
    form: this.customFormRef,
    formControls: [this.customFormControl],
    isValid: () => this.customFormControl.value,
}

```
