### PR TITLE
Add custom account details title and instructions

### DIFF
--- a/login-workflow/CHANGELOG.md
+++ b/login-workflow/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Change Log
+ 
+## v2.1.0 (not published)
+
+-  Added additional `pageTitle` and `pageInstructions` props onto `AccountDetails` for more customization during account registration.  
 
 ## v2.0.0
 

--- a/login-workflow/docs/custom-account-details.md
+++ b/login-workflow/docs/custom-account-details.md
@@ -28,13 +28,15 @@ The `@pxblue/angular-auth-workflow` allows for custom account detail fields to b
 
 ### Populate the `accountDetails` @Input
 
-Each `accountDetails` object has 3 properties:
+Each `accountDetails` object has the following properties:
 
 | Property            | Description                                            |
 | ------------------- | ------------------------------------------------------ | 
-| form                | template ref of the form                                         |
+| form                | Template ref of the form                               |
 | formControls        | A map listing all of the fields in the form            |
-| isValid             | function we run to determine if user-input is valid    |
+| isValid             | Function which determines if user-input is valid       |
+| pageInstructions    | Custom instructions for account details screen         |
+| pageTitle           | Custom title for account details screen                |
 
 Each `accountDetails` represents a new page in the self-registration process.  
 
@@ -59,6 +61,8 @@ ngAfterViewInit(): void {
           form: this.customFormRef,
           formControls: new Map([['custom', this.customFormControl]]),
           isValid: () => this.customFormControl.value,
+          pageTitle: 'Custom page title',
+          pageInstructions: 'Custom page instructions'
       }
   ];
 }

--- a/login-workflow/example/.editorconfig
+++ b/login-workflow/example/.editorconfig
@@ -4,7 +4,7 @@ root = true
 [*]
 charset = utf-8
 indent_style = space
-indent_size = 2
+indent_size = 4
 insert_final_newline = true
 trim_trailing_whitespace = true
 

--- a/login-workflow/example/src/app/app.component.ts
+++ b/login-workflow/example/src/app/app.component.ts
@@ -1,6 +1,11 @@
 import { Component } from '@angular/core';
-import {AbstractControl, ValidatorFn} from "@angular/forms";
-import { PxbAuthSecurityService, SecurityContext, PxbAuthConfig, PXB_LOGIN_VALIDATOR_ERROR_NAME } from '@pxblue/angular-auth-workflow';
+import { AbstractControl, ValidatorFn } from '@angular/forms';
+import {
+    PxbAuthSecurityService,
+    SecurityContext,
+    PxbAuthConfig,
+    PXB_LOGIN_VALIDATOR_ERROR_NAME,
+} from '@pxblue/angular-auth-workflow';
 import { LocalStorageService } from './services/localStorage.service';
 
 @Component({
@@ -23,19 +28,21 @@ export class AppComponent {
         this.pxbAuthConfig.allowDebugMode = true;
         this.pxbAuthConfig.customEmailValidator = this._getCustomEmailValidator();
         this.pxbSecurityService.inferOnAuthenticatedRoute('home');
-        this.pxbAuthConfig.customPasswordRequirements = [{
-            regex: /^((?!password).)*$/,
-            description: 'Does not contain "password"',
-        }];
+        this.pxbAuthConfig.customPasswordRequirements = [
+            {
+                regex: /^((?!password).)*$/,
+                description: 'Does not contain "password"',
+            },
+        ];
     }
 
     private _getCustomEmailValidator(): ValidatorFn {
-      return (control: AbstractControl): { [key: string]: any } | null => {
-        const forbidden = /test/i.test(control.value);
-        return forbidden
-          ? { PXB_LOGIN_VALIDATOR_ERROR_NAME: { message: 'This is a custom error, provided by end user' } }
-          : null;
-      };
+        return (control: AbstractControl): { [key: string]: any } | null => {
+            const forbidden = /test/i.test(control.value);
+            return forbidden
+                ? { PXB_LOGIN_VALIDATOR_ERROR_NAME: { message: 'This is a custom error, provided by end user' } }
+                : null;
+        };
     }
 
     // When a user transitions between being logged in / logged out, update session information.

--- a/login-workflow/example/src/app/pages/auth/auth.component.ts
+++ b/login-workflow/example/src/app/pages/auth/auth.component.ts
@@ -122,6 +122,8 @@ export class AuthComponent {
                 isValid: () => this.countryFormControl.value && this.phoneNumberFormControl.value,
             },
             {
+                pageTitle: 'Career Details',
+                pageInstructions: 'Use the space below to enter your job <strong>title</strong>.',
                 form: this.accountDetailsPage2,
                 formControls: new Map([['jobTitle', this.jobTitleFromControl]]),
                 isValid: () => this.jobTitleFromControl.value,

--- a/login-workflow/example/src/app/pages/auth/auth.component.ts
+++ b/login-workflow/example/src/app/pages/auth/auth.component.ts
@@ -68,9 +68,24 @@ import {
         <ng-template #accountDetailsPage2>
             <form>
                 <mat-form-field appearance="fill">
+                    <mat-label>Company</mat-label>
+                    <input matInput [formControl]="companyFormControl" placeholder="Where do you work?" required />
+                    <mat-error *ngIf="companyFormControl.hasError('required')">
+                        Company is <strong>required</strong>
+                    </mat-error>
+                </mat-form-field>
+            </form>
+            <form>
+                <mat-form-field appearance="fill">
                     <mat-label>Job Title</mat-label>
-                    <input matInput [formControl]="jobTitleFromControl" required (keyup.enter)="attemptGoNext()" />
-                    <mat-error *ngIf="jobTitleFromControl.hasError('required')">
+                    <input
+                        matInput
+                        [formControl]="jobTitleFormControl"
+                        placeholder="What's your title?"
+                        required
+                        (keyup.enter)="attemptGoNext()"
+                    />
+                    <mat-error *ngIf="jobTitleFormControl.hasError('required')">
                         Job Title is <strong>required</strong>
                     </mat-error>
                 </mat-form-field>
@@ -86,9 +101,16 @@ import {
     `,
 })
 export class AuthComponent {
+
+    /* Custom Forms Page 1 */
     countryFormControl: FormControl;
     phoneNumberFormControl: FormControl;
-    jobTitleFromControl: FormControl;
+
+    /* Custom Forms Page 2 */
+    companyFormControl: FormControl;
+    jobTitleFormControl: FormControl;
+
+    /* Account Details Customizations */
     accountDetails: AccountDetails[];
 
     @ViewChild('createAccountVC') createAccountVC: PxbCreateAccountComponent;
@@ -111,7 +133,8 @@ export class AuthComponent {
     initCreateAccountFormControls(): void {
         this.countryFormControl = new FormControl('', Validators.required);
         this.phoneNumberFormControl = new FormControl('');
-        this.jobTitleFromControl = new FormControl('', Validators.required);
+        this.companyFormControl = new FormControl('', Validators.required);
+        this.jobTitleFormControl = new FormControl('', Validators.required);
         this.accountDetails = [
             {
                 form: this.accountDetailsPage1,
@@ -123,10 +146,13 @@ export class AuthComponent {
             },
             {
                 pageTitle: 'Career Details',
-                pageInstructions: 'Use the space below to enter your job <strong>title</strong>.',
+                pageInstructions: 'Use the space below to provide <strong>work details</strong>.',
                 form: this.accountDetailsPage2,
-                formControls: new Map([['jobTitle', this.jobTitleFromControl]]),
-                isValid: () => this.jobTitleFromControl.value,
+                formControls: new Map([
+                    ['company', this.companyFormControl],
+                    ['jobTitle', this.jobTitleFormControl],
+                ]),
+                isValid: () => this.companyFormControl.value && this.jobTitleFormControl.value,
             },
         ];
     }

--- a/login-workflow/package.json
+++ b/login-workflow/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pxblue/angular-auth-workflow",
   "description": "Re-usable workflow components for Authentication and Registration within Eaton applications.",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "scripts": {
     "ng": "ng",
     "watch": "ng build -c demo",

--- a/login-workflow/src/pages/create-account-invite/create-account-invite.component.html
+++ b/login-workflow/src/pages/create-account-invite/create-account-invite.component.html
@@ -51,6 +51,8 @@
         [showDefaultAccountDetails]="true"
         [(firstName)]="firstName"
         [(lastName)]="lastName"
+        [pageTitle]="accountDetails[0]?.pageTitle"
+        [pageInstructions]="accountDetails[0]?.pageInstructions"
         (accountNameValid)="validAccountName = $event"
         (advance)="attemptContinue()"
     >
@@ -61,7 +63,11 @@
     </pxb-create-account-account-details-step>
 
     <!-- Custom Account Details Pages -->
-    <pxb-create-account-account-details-step *ngIf="registrationUtils.isCustomAccountsDetailsPage()">
+    <pxb-create-account-account-details-step
+        *ngIf="registrationUtils.isCustomAccountsDetailsPage()"
+        [pageTitle]="registrationUtils.getCustomAccountDetailsTitle()"
+        [pageInstructions]="registrationUtils.getCustomAccountDetailsInstructions()"
+    >
         <template
             pxb-account-details
             [ngTemplateOutlet]="registrationUtils.getCustomAccountDetailsTemplate()"

--- a/login-workflow/src/pages/create-account/create-account.component.html
+++ b/login-workflow/src/pages/create-account/create-account.component.html
@@ -31,6 +31,8 @@
     [showDefaultAccountDetails]="true"
     [(firstName)]="firstName"
     [(lastName)]="lastName"
+    [pageTitle]="accountDetails[0]?.pageTitle"
+    [pageInstructions]="accountDetails[0]?.pageInstructions"
     (accountNameValid)="validAccountName = $event"
     (advance)="attemptContinue()"
 >
@@ -38,7 +40,11 @@
 </pxb-create-account-account-details-step>
 
 <!-- Custom Account Details Pages -->
-<pxb-create-account-account-details-step *ngIf="registrationUtils.isCustomAccountsDetailsPage()">
+<pxb-create-account-account-details-step
+    *ngIf="registrationUtils.isCustomAccountsDetailsPage()"
+    [pageTitle]="registrationUtils.getCustomAccountDetailsTitle()"
+    [pageInstructions]="registrationUtils.getCustomAccountDetailsInstructions()"
+>
     <template pxb-account-details [ngTemplateOutlet]="registrationUtils.getCustomAccountDetailsTemplate()"></template>
 </pxb-create-account-account-details-step>
 

--- a/login-workflow/src/pages/create-account/create-account.component.ts
+++ b/login-workflow/src/pages/create-account/create-account.component.ts
@@ -16,6 +16,8 @@ import { PxbAuthTranslations } from '../../translations/auth-translations';
 const ACCOUNT_DETAILS_STARTING_PAGE = 4;
 
 export type AccountDetails = {
+    pageTitle?: string;
+    pageInstructions?: string;
     form: TemplateRef<MatFormField>;
     formControls: Map<string, FormControl>;
     isValid: () => boolean;

--- a/login-workflow/src/pages/create-account/create-account.service.ts
+++ b/login-workflow/src/pages/create-account/create-account.service.ts
@@ -86,6 +86,20 @@ export class CreateAccountService {
         }
     }
 
+    getCustomAccountDetailsTitle(): string {
+        const detailsIndex = this.currentPage - this.detailsStartPage; /* index of custom accountDetails to use. */
+        if (this._hasDetailsAtIndex(detailsIndex)) {
+            return this.accountDetails[detailsIndex].pageTitle;
+        }
+    }
+
+    getCustomAccountDetailsInstructions(): string {
+        const detailsIndex = this.currentPage - this.detailsStartPage; /* index of custom accountDetails to use. */
+        if (this._hasDetailsAtIndex(detailsIndex)) {
+            return this.accountDetails[detailsIndex].pageInstructions;
+        }
+    }
+
     /* Called upon completing the self-registration process, empties all forms.  */
     clearAccountDetails(): void {
         for (const detail of this.accountDetails) {

--- a/login-workflow/src/pages/create-account/steps/account-details/account-details.component.ts
+++ b/login-workflow/src/pages/create-account/steps/account-details/account-details.component.ts
@@ -10,12 +10,15 @@ import { PxbAuthTranslations } from '../../../../translations/auth-translations'
     selector: 'pxb-create-account-account-details-step',
     styleUrls: ['account-details.component.scss'],
     template: `
-        <div class="mat-title pxb-auth-title" [innerHTML]="translate.CREATE_ACCOUNT.ACCOUNT_DETAILS.TITLE"></div>
+        <div
+            class="mat-title pxb-auth-title"
+            [innerHTML]="pageTitle || translate.CREATE_ACCOUNT.ACCOUNT_DETAILS.TITLE"
+        ></div>
         <div class="pxb-auth-full-height">
             <p
                 class="mat-body-1"
                 style="margin-bottom: 24px;"
-                [innerHTML]="translate.CREATE_ACCOUNT.ACCOUNT_DETAILS.INSTRUCTIONS"
+                [innerHTML]="pageInstructions || translate.CREATE_ACCOUNT.ACCOUNT_DETAILS.INSTRUCTIONS"
             ></p>
             <mat-divider class="pxb-auth-divider" style="margin-top: 16px; margin-bottom: 32px;"></mat-divider>
             <div class="pxb-account-details-body">
@@ -77,6 +80,8 @@ export class PxbAccountDetailsComponent implements OnInit {
     @Input() showDefaultAccountDetails = false; // Used to hide defaults whenever there are custom account detail forms.
     @Input() firstName: string;
     @Input() lastName: string;
+    @Input() pageTitle: string;
+    @Input() pageInstructions: string;
     @Output() firstNameChange: EventEmitter<string> = new EventEmitter<string>();
     @Output() lastNameChange: EventEmitter<string> = new EventEmitter<string>();
     @Output() accountNameValid = new EventEmitter<boolean>();


### PR DESCRIPTION
<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Add custom account details page title and instructions

Custom account registration details are passed into a `<pxb-create-account>` component through the `accountDetails` prop.   I've added `pageTitle` and `pageInstructions` onto this customization object.  If no title/instructions are provided, we default to the text found in the translations file. 
