### PR TITLE
Feature/pre auth home page

### DIFF
--- a/login-workflow/CHANGELOG.md
+++ b/login-workflow/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 -  Added additional `pageTitle` and `pageInstructions` props onto `AccountDetails` for more customization during account registration.  
 -  Added `registrationSuccessScreen` prop to `<pxb-create-account>` & `<pxb-create-account-invite>` component for success screen customization.
+-  Added `authGuardRedirectRoute` prop to `PxbAuthConfig`. 
 
 ## v2.0.0 (March 31, 2021)
 

--- a/login-workflow/docs/existing-project-integration.md
+++ b/login-workflow/docs/existing-project-integration.md
@@ -44,6 +44,8 @@ In your `app.routing.ts` config, add the auth-specific routes. `authSubRoutes` i
 The configuration below has the base URL redirect to the login screen. 
 All routes that require authentication can be protected using the `PxbAuthGuard`.  This guard will prevent routes from being accessed from unauthenticated users.  
 
+> By default, the `PxbAuthGuard` will redirect an unauthenticated user to the empty route; the redirect url can be configured in the `PxbAuthConfig` service. 
+
 In the example below, the `/home` route can only be accessed if a user is logged in.
 
 ```
@@ -65,6 +67,8 @@ const routes: Routes = [
 ];
 ```
 
+> If your project requires a custom pre-authentication/welcome screen, this can be supported by updating the root URL to redirect to your custom page instead of the `AUTH_ROUTES.AUTH_WORK` routes. 
+
 
 
 The following is the list of default routes found in `getAuthSubRoutes()`.  
@@ -78,7 +82,7 @@ The following is the list of default routes found in `getAuthSubRoutes()`.
 | Self Registration   | the first screen of the self-registration flow         | `'/auth/register/create-account'` |
 | Support             | the contact/support screen                             | `'/auth/support'`                 |
 
-Any route url can be overwritten by altering the `AUTH_ROUTES` object. 
+Any `@pxblue/angular-auth-workflow` route can be overwritten by editing the `AUTH_ROUTES` object. 
 
 #### Provide API Services
 

--- a/login-workflow/docs/existing-project-integration.md
+++ b/login-workflow/docs/existing-project-integration.md
@@ -67,7 +67,7 @@ const routes: Routes = [
 ];
 ```
 
-> If your project requires a custom pre-authentication/welcome screen, this can be supported by updating the root URL to redirect to your custom page instead of the `AUTH_ROUTES.AUTH_WORK` routes. 
+> If your project requires a custom pre-authentication/welcome screen, this can be supported by updating the root URL to redirect to your custom page instead of the `AUTH_ROUTES.AUTH_WORKFLOW` routes. 
 
 
 

--- a/login-workflow/docs/existing-project-integration.md
+++ b/login-workflow/docs/existing-project-integration.md
@@ -44,7 +44,7 @@ In your `app.routing.ts` config, add the auth-specific routes. `authSubRoutes` i
 The configuration below has the base URL redirect to the login screen. 
 All routes that require authentication can be protected using the `PxbAuthGuard`.  This guard will prevent routes from being accessed from unauthenticated users.  
 
-> By default, the `PxbAuthGuard` will redirect an unauthenticated user to the empty route; the redirect url can be configured in the `PxbAuthConfig` service. 
+> By default, the `PxbAuthGuard` will redirect an unauthenticated user to the `AUTH_ROUTES.AUTH_WORKFLOW` route. If you would like to redirect the users to a different screen, the destination url can be configured in the `PxbAuthConfig` service with the `authGuardRedirectRoute` property.
 
 In the example below, the `/home` route can only be accessed if a user is logged in.
 

--- a/login-workflow/docs/services.md
+++ b/login-workflow/docs/services.md
@@ -85,23 +85,7 @@ constructor(pxbAuthConfig: PxbAuthConfig) {
     -   When true, shows the Remember Me option on the Login Page.
     -   Default: true
     
-## PxbAuthSecurityService 
 
-`PxbAuthSecurityService` is a service used to store authentication state.  Pages with the auth workflow will look to this service for information about a current user and their authentication state. 
-
-### Usage 
-
-```
-import { PxbAuthSecurityService, AUTH_ROUTE } from '@pxblue/angular-auth-workflow';
-
-constructor(private readonly _pxbSecurityService: PxbAuthSecurityService) {}
-
-logout(): void {
-   this._pxbSecurityService.updateSecurityState({ isAuthenticatedUser: false });
-   void this._router.navigate([AUTH_ROUTE]);
-}
-```
-   
 ## PxbAuthSecurityService
 
 `PxbAuthSecurityService` stores user authentication state and updates as a user logs in/out. 

--- a/login-workflow/docs/services.md
+++ b/login-workflow/docs/services.md
@@ -104,7 +104,8 @@ logout(): void {
    
 ## PxbAuthSecurityService
 
-`PxbAuthSecurityService` provides user authentication state and updates as a user logs in/out. Pages within the workflow use this service for info about whether or not a user is authenticated, check if an API call is happening, etc.  It is not meant to authenticate the user or hold credential information. 
+`PxbAuthSecurityService` stores user authentication state and updates as a user logs in/out. 
+Pages within the workflow use this service to check if a user is authenticated, check if an API call is happening, etc. 
 
 ### Usage
 

--- a/login-workflow/docs/services.md
+++ b/login-workflow/docs/services.md
@@ -36,6 +36,9 @@ constructor(pxbAuthConfig: PxbAuthConfig) {
 -   **allowDebugMode** (optional): _`boolean`_
     -   When true, presents a debug button on the login screen to allow access to deep link-based screens/flows
     -   Default: false
+-   **authGuardRedirectRoute** (optional) _`string`_
+    -   Whenever the PxbAuthGuard blocks navigation to an auth-protected page, navigate to this route.
+    -   Default: ''
 -   **backgroundImage** (optional): _`string`_
     -   Background image to be used within the auth workflow
 -   **contactEmail** (optional): _`string`_

--- a/login-workflow/example/src/app/app.component.ts
+++ b/login-workflow/example/src/app/app.component.ts
@@ -1,6 +1,6 @@
 import { Component } from '@angular/core';
 import { AbstractControl, ValidatorFn } from '@angular/forms';
-import { PxbAuthSecurityService, SecurityContext, PxbAuthConfig } from '@pxblue/angular-auth-workflow';
+import { PxbAuthSecurityService, SecurityContext, PxbAuthConfig, AUTH_ROUTES } from '@pxblue/angular-auth-workflow';
 import { LocalStorageService } from './services/localStorage.service';
 
 @Component({

--- a/login-workflow/example/src/app/app.module.ts
+++ b/login-workflow/example/src/app/app.module.ts
@@ -26,9 +26,10 @@ import { MatSelectModule } from '@angular/material/select';
 import { MatToolbarModule } from '@angular/material/toolbar';
 import { MatIconModule } from '@angular/material/icon';
 import { MatDividerModule } from '@angular/material/divider';
+import {PreAuthComponent} from "./pages/pre-auth/pre-auth.component";
 
 @NgModule({
-    declarations: [AppComponent, HomeComponent, AuthComponent, DashboardComponent, LoginErrorDialogComponent],
+    declarations: [AppComponent, PreAuthComponent, HomeComponent, AuthComponent, DashboardComponent, LoginErrorDialogComponent],
     imports: [
         AppRoutingModule,
         BrowserModule,

--- a/login-workflow/example/src/app/app.module.ts
+++ b/login-workflow/example/src/app/app.module.ts
@@ -26,10 +26,17 @@ import { MatSelectModule } from '@angular/material/select';
 import { MatToolbarModule } from '@angular/material/toolbar';
 import { MatIconModule } from '@angular/material/icon';
 import { MatDividerModule } from '@angular/material/divider';
-import {PreAuthComponent} from "./pages/pre-auth/pre-auth.component";
+import { PreAuthComponent } from './pages/pre-auth/pre-auth.component';
 
 @NgModule({
-    declarations: [AppComponent, PreAuthComponent, HomeComponent, AuthComponent, DashboardComponent, LoginErrorDialogComponent],
+    declarations: [
+        AppComponent,
+        PreAuthComponent,
+        HomeComponent,
+        AuthComponent,
+        DashboardComponent,
+        LoginErrorDialogComponent,
+    ],
     imports: [
         AppRoutingModule,
         BrowserModule,

--- a/login-workflow/example/src/app/app.routing.ts
+++ b/login-workflow/example/src/app/app.routing.ts
@@ -4,7 +4,7 @@ import { getAuthSubRoutes, PxbAuthGuard, AUTH_ROUTES } from '@pxblue/angular-aut
 import { HomeComponent } from './pages/home/home.component';
 import { AuthComponent } from './pages/auth/auth.component';
 import { DashboardComponent } from './pages/dashboard/dashboard.component';
-import {PreAuthComponent} from "./pages/pre-auth/pre-auth.component";
+import { PreAuthComponent } from './pages/pre-auth/pre-auth.component';
 
 // The default workflow routes can be overwritten if needed.
 // This feature only works if ivy is enabled.
@@ -13,7 +13,8 @@ AUTH_ROUTES.CONTACT_SUPPORT = 'assistance';
 
 const authWorkflowRoutes = getAuthSubRoutes();
 const routes: Routes = [
-    { path: '', redirectTo: 'pre-auth', pathMatch: 'full' },
+    // { path: '', redirectTo: 'pre-auth', pathMatch: 'full' },
+    { path: '', redirectTo: AUTH_ROUTES.AUTH_WORKFLOW, pathMatch: 'full' },
     { path: AUTH_ROUTES.AUTH_WORKFLOW, component: AuthComponent, children: authWorkflowRoutes },
     {
         path: '',
@@ -23,7 +24,7 @@ const routes: Routes = [
             { path: 'dashboard', component: DashboardComponent },
         ],
     },
-    { path: 'pre-auth', component: PreAuthComponent, pathMatch: 'full' }
+    { path: 'pre-auth', component: PreAuthComponent, pathMatch: 'full' },
 ];
 
 // configures NgModule imports and exports

--- a/login-workflow/example/src/app/app.routing.ts
+++ b/login-workflow/example/src/app/app.routing.ts
@@ -4,6 +4,7 @@ import { getAuthSubRoutes, PxbAuthGuard, AUTH_ROUTES } from '@pxblue/angular-aut
 import { HomeComponent } from './pages/home/home.component';
 import { AuthComponent } from './pages/auth/auth.component';
 import { DashboardComponent } from './pages/dashboard/dashboard.component';
+import {PreAuthComponent} from "./pages/pre-auth/pre-auth.component";
 
 // The default workflow routes can be overwritten if needed.
 // This feature only works if ivy is enabled.
@@ -12,7 +13,7 @@ AUTH_ROUTES.CONTACT_SUPPORT = 'assistance';
 
 const authWorkflowRoutes = getAuthSubRoutes();
 const routes: Routes = [
-    { path: '', redirectTo: AUTH_ROUTES.AUTH_WORKFLOW, pathMatch: 'full' },
+    { path: '', redirectTo: 'pre-auth', pathMatch: 'full' },
     { path: AUTH_ROUTES.AUTH_WORKFLOW, component: AuthComponent, children: authWorkflowRoutes },
     {
         path: '',
@@ -22,6 +23,7 @@ const routes: Routes = [
             { path: 'dashboard', component: DashboardComponent },
         ],
     },
+    { path: 'pre-auth', component: PreAuthComponent, pathMatch: 'full' }
 ];
 
 // configures NgModule imports and exports

--- a/login-workflow/example/src/app/pages/pre-auth/pre-auth.component.ts
+++ b/login-workflow/example/src/app/pages/pre-auth/pre-auth.component.ts
@@ -1,0 +1,20 @@
+import {Component} from '@angular/core';
+import {Router} from "@angular/router";
+import {AUTH_ROUTES} from "@pxblue/angular-auth-workflow";
+
+@Component({
+    selector: 'app-pre-auth',
+    template: `
+        <button color="primary"
+                (click)="router.navigate([routes.AUTH_WORKFLOW])" mat-stroked-button>Go Login</button>
+        <button color="primary"
+                (click)="router.navigate(['/dashboard'])" mat-flat-button>Go Auth Guarded Page</button>
+
+    `,
+})
+export class PreAuthComponent {
+
+    routes = AUTH_ROUTES;
+    constructor(public router: Router) {
+    }
+}

--- a/login-workflow/example/src/app/pages/pre-auth/pre-auth.component.ts
+++ b/login-workflow/example/src/app/pages/pre-auth/pre-auth.component.ts
@@ -1,20 +1,15 @@
-import {Component} from '@angular/core';
-import {Router} from "@angular/router";
-import {AUTH_ROUTES} from "@pxblue/angular-auth-workflow";
+import { Component } from '@angular/core';
+import { Router } from '@angular/router';
+import { AUTH_ROUTES } from '@pxblue/angular-auth-workflow';
 
 @Component({
     selector: 'app-pre-auth',
     template: `
-        <button color="primary"
-                (click)="router.navigate([routes.AUTH_WORKFLOW])" mat-stroked-button>Go Login</button>
-        <button color="primary"
-                (click)="router.navigate(['/dashboard'])" mat-flat-button>Go Auth Guarded Page</button>
-
+        <button color="primary" (click)="router.navigate([routes.AUTH_WORKFLOW])" mat-stroked-button>Go Login</button>
+        <button color="primary" (click)="router.navigate(['/dashboard'])" mat-flat-button>Go Auth Guarded Page</button>
     `,
 })
 export class PreAuthComponent {
-
     routes = AUTH_ROUTES;
-    constructor(public router: Router) {
-    }
+    constructor(public router: Router) {}
 }

--- a/login-workflow/src/guards/auth-guard.ts
+++ b/login-workflow/src/guards/auth-guard.ts
@@ -1,15 +1,21 @@
 import { Injectable } from '@angular/core';
 import { Router, CanActivate } from '@angular/router';
 import { PxbAuthSecurityService } from '../services/state/auth-security.service';
+import { PxbAuthConfig } from '../services/config/auth-config';
 
 @Injectable({
     providedIn: 'root',
 })
 export class PxbAuthGuard implements CanActivate {
-    constructor(public securityService: PxbAuthSecurityService, public router: Router) {}
+    constructor(
+        public pxbAuthConfig: PxbAuthConfig,
+        public securityService: PxbAuthSecurityService,
+        public router: Router
+    ) {}
+
     canActivate(): boolean {
         if (!this.securityService.getSecurityState().isAuthenticatedUser) {
-            void this.router.navigate(['']);
+            void this.router.navigate([this.pxbAuthConfig.authGuardRedirectRoute]);
             return false;
         }
         return true;

--- a/login-workflow/src/services/config/auth-config.ts
+++ b/login-workflow/src/services/config/auth-config.ts
@@ -14,6 +14,8 @@ export type PasswordRequirement = {
     providedIn: 'root',
 })
 export class PxbAuthConfig implements PxbAuthConfig {
+    authGuardRedirectRoute: string = '';
+
     languageCode = 'EN';
     allowDebugMode = false;
     showRememberMe = true;

--- a/login-workflow/src/services/config/auth-config.ts
+++ b/login-workflow/src/services/config/auth-config.ts
@@ -14,7 +14,7 @@ export type PasswordRequirement = {
     providedIn: 'root',
 })
 export class PxbAuthConfig implements PxbAuthConfig {
-    authGuardRedirectRoute: string = '';
+    authGuardRedirectRoute = '';
 
     languageCode = 'EN';
     allowDebugMode = false;


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes #72 

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- I added a new prop that allows uses to specify the redirect route whenever the PxbAuthGuard blocks navigation.

-  I made a POC pre-authenticated landing page which is deployed here:  https://pxblue-temp.web.app
- In the code, I've kept the default behavior so that the root url will redirect you to the landing page, not the pre-auth page. 

