### PR TITLE
Feature/reasonable defaults

### DIFF
--- a/login-workflow/CHANGELOG.md
+++ b/login-workflow/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-## v2.4.0 (September 21, 2021)
+## v2.4.0 (Not yet published)
 
 ### Added 
 

--- a/login-workflow/CHANGELOG.md
+++ b/login-workflow/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-## v2.4.0 (Not published)
+## v2.4.0 (September 21, 2021)
 
 ### Added 
 

--- a/login-workflow/package.json
+++ b/login-workflow/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pxblue/angular-auth-workflow",
   "description": "Re-usable workflow components for Authentication and Registration within Eaton applications.",
-  "version": "2.4.0",
+  "version": "2.4.0-beta.1",
   "scripts": {
     "ng": "ng",
     "watch": "ng build -c demo",

--- a/login-workflow/package.json
+++ b/login-workflow/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pxblue/angular-auth-workflow",
   "description": "Re-usable workflow components for Authentication and Registration within Eaton applications.",
-  "version": "2.4.0-beta.0",
+  "version": "2.4.0",
   "scripts": {
     "ng": "ng",
     "watch": "ng build -c demo",

--- a/login-workflow/src/pages/login/login.component.ts
+++ b/login-workflow/src/pages/login/login.component.ts
@@ -91,7 +91,9 @@ export class PxbLoginComponent implements OnInit, AfterViewInit {
                 this._pxbSecurityService.setLoading(false);
             })
             .catch((errorData: LoginErrorData) => {
-                const mode = errorData.mode || ['dialog'];
+                // If a user provides `undefined` rejection data, don't throw an error.
+                const rejectionData = errorData || {} as LoginErrorData;
+                const mode = rejectionData.mode || ['dialog'];
 
                 if (mode.includes('none')) {
                     this._pxbSecurityService.onUserNotAuthenticated();
@@ -99,20 +101,23 @@ export class PxbLoginComponent implements OnInit, AfterViewInit {
                     return;
                 }
 
-                this.position = errorData.position || 'top';
-
-                this.dismissible = errorData.dismissible === undefined ? true : errorData.dismissible;
+                this.position = rejectionData.position || 'top';
+                this.dismissible = rejectionData.dismissible === undefined ? true : rejectionData.dismissible;
                 this.showDialog = mode.includes('dialog');
                 this.showCardError = mode.includes('message-box');
                 this.showFormErr = mode.includes('form');
+                const errorTitle = rejectionData.title || this.translate().LOGIN.ERROR_TITLE;
+                this.errorMessage = rejectionData.message || this.translate().LOGIN.INVALID_CREDENTIALS;
 
                 if (this.showCardError) {
                     this.showCardError = true;
                 }
                 if (this.showDialog) {
-                    this._pxbLoginErrorDialogService.openDialog(errorData);
+                    this._pxbLoginErrorDialogService.openDialog({
+                        title: errorTitle,
+                        message: this.errorMessage
+                    });
                 }
-                this.errorMessage = errorData.message || this.translate().LOGIN.INVALID_CREDENTIALS;
                 this._pxbSecurityService.onUserNotAuthenticated();
                 this._pxbSecurityService.setLoading(false);
             });

--- a/login-workflow/src/pages/login/login.component.ts
+++ b/login-workflow/src/pages/login/login.component.ts
@@ -92,7 +92,7 @@ export class PxbLoginComponent implements OnInit, AfterViewInit {
             })
             .catch((errorData: LoginErrorData) => {
                 // If a user provides `undefined` rejection data, don't throw an error.
-                const rejectionData = errorData || {} as LoginErrorData;
+                const rejectionData = errorData || ({} as LoginErrorData);
                 const mode = rejectionData.mode || ['dialog'];
 
                 if (mode.includes('none')) {
@@ -115,7 +115,7 @@ export class PxbLoginComponent implements OnInit, AfterViewInit {
                 if (this.showDialog) {
                     this._pxbLoginErrorDialogService.openDialog({
                         title: errorTitle,
-                        message: this.errorMessage
+                        message: this.errorMessage,
                     });
                 }
                 this._pxbSecurityService.onUserNotAuthenticated();

--- a/login-workflow/src/translations/auth-translations.ts
+++ b/login-workflow/src/translations/auth-translations.ts
@@ -24,6 +24,7 @@ export type PxbAuthTranslations = {
         FORGOT_PASSWORD_LINK: string;
         TEST_INVITE_LINK: string;
         INVALID_CREDENTIALS: string;
+        ERROR_TITLE: string;
     };
     FORGOT_PASSWORD: {
         TITLE: string;

--- a/login-workflow/src/translations/chinese.ts
+++ b/login-workflow/src/translations/chinese.ts
@@ -28,6 +28,7 @@ export const pxbAuthChineseTranslations: PxbAuthTranslations = {
         FORGOT_PASSWORD_LINK: '[测试忘记密码的电子邮件]',
         TEST_INVITE_LINK: '[测试邀请注册]',
         INVALID_CREDENTIALS: '邮箱地址或密码错误',
+        ERROR_TITLE: '错误！',
     },
     CHANGE_PASSWORD: {
         TITLE: '修改密码',

--- a/login-workflow/src/translations/english.ts
+++ b/login-workflow/src/translations/english.ts
@@ -28,6 +28,7 @@ export const pxbAuthEnglishTranslations: PxbAuthTranslations = {
         FORGOT_PASSWORD_LINK: '[Test Forgot Password Email]',
         TEST_INVITE_LINK: '[Test Invite Register]',
         INVALID_CREDENTIALS: 'Incorrect Email or Password',
+        ERROR_TITLE: 'Error',
     },
     CHANGE_PASSWORD: {
         TITLE: 'Change Password',

--- a/login-workflow/src/translations/french.ts
+++ b/login-workflow/src/translations/french.ts
@@ -28,6 +28,7 @@ export const pxbAuthFrenchTranslations: PxbAuthTranslations = {
         FORGOT_PASSWORD_LINK: '[Test Mot de passe oublié Email]',
         TEST_INVITE_LINK: "[Tester le registre d'invitation]",
         INVALID_CREDENTIALS: 'Email ou mot de passe incorrect',
+        ERROR_TITLE: 'Erreur',
     },
     CHANGE_PASSWORD: {
         TITLE: 'Changer le mot de passe',

--- a/login-workflow/src/translations/spanish.ts
+++ b/login-workflow/src/translations/spanish.ts
@@ -28,6 +28,7 @@ export const pxbAuthSpanishTranslations: PxbAuthTranslations = {
         FORGOT_PASSWORD_LINK: '[Prueba Olvidé mi contraseña Correo electrónico]',
         TEST_INVITE_LINK: '[Prueba Invitar Registrarse]',
         INVALID_CREDENTIALS: 'Correo electrónico o contraseña incorrectos',
+        ERROR_TITLE: '¡Error!',
     },
     CHANGE_PASSWORD: {
         TITLE: 'Contraseña cambiada',


### PR DESCRIPTION
<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
-  Gracefully handle the situation where a user rejects a failed login attempt with `undefined`. 
-  Use translated defaults for login & message-box `title` & `message`. 

